### PR TITLE
gpu dynamic memory

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/ClusterLinesGPU.h
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/ClusterLinesGPU.h
@@ -65,7 +65,6 @@ class ClusterLinesGPU final
  private:
   float mAMatrix[6];         // AX=B
   float mBMatrix[3];         // AX=B
-  int mLabels[2];            // labels
   float mVertexCandidate[3]; // vertex candidate
   float mWeightMatrix[9];    // weight matrix
   float mVertex[3];          // cluster centroid position

--- a/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/Stream.h
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/Stream.h
@@ -17,6 +17,7 @@
 #define ITSTRACKINGGPU_STREAM_H_
 
 #include "ITStracking/Definitions.h"
+
 #ifdef __HIPCC__
 #include <hip/hip_runtime.h>
 #endif
@@ -34,9 +35,6 @@ class Stream final
  public:
   Stream();
   ~Stream();
-
-  Stream(const Stream&) = delete;
-  Stream& operator=(const Stream&) = delete;
 
   const GPUStream& get() const;
 

--- a/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/TimeFrameGPU.h
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/TimeFrameGPU.h
@@ -66,7 +66,7 @@ class GpuTimeFramePartition
   /// Most relevant operations
   void allocate(const size_t, Stream&);
   void reset(const size_t, const Task);
-  void copyDeviceData(const size_t, const int, Stream);
+  size_t copyDeviceData(const size_t, const int, Stream&);
 
   /// Interface
   int* getDeviceROframesClusters(const int);
@@ -91,13 +91,15 @@ class GpuTimeFramePartition
   int* getDeviceNExclusiveFoundLines() { return mNExclusiveFoundLinesDevice; }
   unsigned char* getDeviceUsedTracklets() { return mUsedTrackletsDevice; }
 
- private:
   /// Host
   std::array<gsl::span<const Cluster>, nLayers> mHostClusters;
+  std::array<gsl::span<const int>, nLayers> mHostROframesClusters;
 
   /// Device
   std::array<int*, nLayers> mROframesClustersDevice; // layers x roframes
   std::array<Cluster*, nLayers> mClustersDevice;
+
+ private:
   std::array<unsigned char*, nLayers> mUsedClustersDevice;
   std::array<TrackingFrameInfo*, nLayers> mTrackingFrameInfoDevice;
   std::array<int*, nLayers> mClusterExternalIndicesDevice;
@@ -133,6 +135,8 @@ class TimeFrameGPU : public TimeFrame
   ~TimeFrameGPU();
 
   /// Most relevant operations
+  void registerHostMemory(const int);
+  void unregisterHostMemory(const int);
   void initialise(const int, const TrackingParameters&, const int, const IndexTableUtils* utils = nullptr);
   void initDevice(const int, const IndexTableUtils*, const int);
   void initDevicePartitions(const int, const int);
@@ -144,7 +148,8 @@ class TimeFrameGPU : public TimeFrame
   int getNClustersInRofSpan(const int, const int, const int) const;
 
  private:
-  bool mInitialised = false;
+  bool mDeviceInitialised = false;
+  bool mHostRegistered = false;
   std::vector<GpuTimeFramePartition<nLayers>> mMemPartitions;
   TimeFrameGPUConfig mGpuConfig;
 
@@ -159,16 +164,18 @@ class TimeFrameGPU : public TimeFrame
 
 template <int nLayers>
 template <Task task>
-size_t TimeFrameGPU<nLayers>::loadPartitionData(const size_t part, const size_t offset) // offset: readout frame to start from 
+size_t TimeFrameGPU<nLayers>::loadPartitionData(const size_t part, const size_t offset) // offset: readout frame to start from
 {
-  auto nRof = GpuTimeFramePartition<nLayers>::computeRofPerPartition(mGpuConfig, mAvailMemGB);
-  mMemPartitions[part].reset(GpuTimeFramePartition<nLayers>::computeRofPerPartition(mGpuConfig, mAvailMemGB), task);
+  size_t nRof{0};
+
+  mMemPartitions[part].reset(GpuTimeFramePartition<nLayers>::computeRofPerPartition(mGpuConfig, mAvailMemGB), task); // Reset partitions memory
   if constexpr ((bool)task) {
-    mMemPartitions[part].copyDeviceData(startRof, 3, mGpuStreams[part]);
+    nRof = mMemPartitions[part].copyDeviceData(offset, 3, mGpuStreams[part]);
   } else {
-    mMemPartitions[part].copyDeviceData(startRof, nLayers, mGpuStreams[part]);
+    nRof = mMemPartitions[part].copyDeviceData(offset, nLayers, mGpuStreams[part]);
   }
-  return 
+  LOGP(info, "In partition {}: loaded {} readout frames starting from {}", part, nRof, offset);
+  return nRof;
 }
 
 template <int nLayers>
@@ -176,276 +183,6 @@ inline int TimeFrameGPU<nLayers>::getNClustersInRofSpan(const int rofIdstart, co
 {
   return static_cast<int>(mROframesClusters[layerId][(rofIdstart + rofSpanSize) < mROframesClusters.size() ? rofIdstart + rofSpanSize : mROframesClusters.size() - 1] - mROframesClusters[layerId][rofIdstart]);
 }
-
-// #ifdef __HIPCC__
-// #include <hip/hip_runtime.h>
-// #endif
-
-// #include "ITStracking/TimeFrame.h"
-// #include "ITStracking/Configuration.h"
-
-// #include "ITStrackingGPU/ClusterLinesGPU.h"
-// #include "ITStrackingGPU/Stream.h"
-
-// #include "Array.h"
-// #include "Vector.h"
-
-// #include "GPUCommonDef.h"
-// #include "GPUCommonMath.h"
-// #include "GPUCommonLogger.h"
-
-// namespace o2
-// {
-
-// namespace its
-// {
-// using namespace constants::its2;
-
-// class TimeFrameGPUConfig;
-// namespace gpu
-// {
-
-// template <int nLayers = 7>
-// class TimeFrameGPU : public TimeFrame
-// {
-
-//  public:
-//   TimeFrameGPU();
-//   ~TimeFrameGPU();
-
-//   void checkBufferSizes();
-//   void initialise(const int iteration,
-//                   const TrackingParameters& trkParam,
-//                   const int maxLayers);
-//   template <unsigned char isTracker = false>
-//   void initialiseDevice(const TrackingParameters&);
-//   /// Getters
-//   float getDeviceMemory();
-//   Cluster* getDeviceClustersOnLayer(const int rofId, const int layerId) const;
-//   unsigned char* getDeviceUsedClustersOnLayer(const int rofId, const int layerId);
-//   int* getDeviceROframesClustersOnLayer(const int layerId) const { return mROframesClustersD[layerId].get(); }
-//   int getNClustersLayer(const int rofId, const int layerId) const;
-//   TimeFrameGPUConfig& getConfig() { return mConfig; }
-//   gpu::Stream& getStream(const int iLayer) { return mStreamArray[iLayer]; }
-//   std::vector<int>& getTrackletSizeHost() { return mTrackletSizeHost; }
-//   std::vector<int>& getCellSizeHost() { return mCellSizeHost; }
-
-//   // Vertexer only
-//   int* getDeviceNTrackletsCluster(int rofId, int combId);
-//   int* getDeviceIndexTables(const int layerId) { return mIndexTablesD[layerId].get(); }
-//   int* getDeviceIndexTableAtRof(const int layerId, const int rofId) { return mIndexTablesD[layerId].get() + rofId * (ZBins * PhiBins + 1); }
-//   unsigned char* getDeviceUsedTracklets(const int rofId);
-//   Line* getDeviceLines(const int rofId);
-//   Tracklet* getDeviceTrackletsVertexerOnly(const int rofId, const int layerId); // this method uses the cluster table for layer 1 for any layer. It is used for the vertexer only.
-//   Tracklet* getDeviceTracklets(const int rofId, const int layerId);
-//   Tracklet* getDeviceTrackletsAll(const int layerId);
-//   Cell* getDeviceCells(const int layerId);
-//   int* getDeviceTrackletsLookupTable(const int rofId, const int layerId);
-//   int* getDeviceCellsLookupTable(const int layerId);
-//   int* getDeviceNFoundLines(const int rofId);
-//   int* getDeviceExclusiveNFoundLines(const int rofId);
-//   int* getDeviceCUBBuffer(const size_t rofId);
-//   int* getDeviceNFoundTracklets() const { return mDeviceFoundTracklets; };
-//   int* getDeviceNFoundCells() const { return mDeviceFoundCells; };
-//   float* getDeviceXYCentroids(const int rofId);
-//   float* getDeviceZCentroids(const int rofId);
-//   int* getDeviceXHistograms(const int rofId);
-//   int* getDeviceYHistograms(const int rofId);
-//   int* getDeviceZHistograms(const int rofId);
-//   gpu::StaticTrackingParameters<nLayers>* getDeviceTrackingParameters() const { return mDeviceTrackingParams; }
-//   IndexTableUtils* getDeviceIndexTableUtils() const { return mDeviceIndexTableUtils; }
-
-// #ifdef __HIPCC__
-//   hipcub::KeyValuePair<int, int>* getTmpVertexPositionBins(const int rofId);
-// #else
-//   cub::KeyValuePair<int, int>* getTmpVertexPositionBins(const int rofId);
-// #endif
-//   float* getDeviceBeamPosition(const int rofId);
-//   Vertex* getDeviceVertices(const int rofId);
-
-//  private:
-//   TimeFrameGPUConfig mConfig;
-//   std::array<gpu::Stream, nLayers + 1> mStreamArray;
-//   std::vector<int> mTrackletSizeHost;
-//   std::vector<int> mCellSizeHost;
-//   // Per-layer information, do not expand at runtime
-//   std::array<Vector<Cluster>, nLayers> mClustersD;
-//   std::array<Vector<unsigned char>, nLayers> mUsedClustersD;
-//   std::array<Vector<TrackingFrameInfo>, nLayers> mTrackingFrameInfoD;
-//   std::array<Vector<int>, nLayers - 1> mIndexTablesD;
-//   std::array<Vector<int>, nLayers> mClusterExternalIndicesD;
-//   std::array<Vector<Tracklet>, nLayers - 1> mTrackletsD;
-//   std::array<Vector<int>, nLayers - 1> mTrackletsLookupTablesD;
-//   std::array<Vector<Cell>, nLayers - 2> mCellsD;
-//   std::array<Vector<int>, nLayers - 2> mCellsLookupTablesD;
-//   std::array<Vector<int>, nLayers> mROframesClustersD; // layers x roframes
-//   int* mCUBTmpBuffers;
-//   int* mDeviceFoundTracklets;
-//   int* mDeviceFoundCells;
-//   gpu::StaticTrackingParameters<nLayers>* mDeviceTrackingParams;
-//   IndexTableUtils* mDeviceIndexTableUtils;
-
-//   // Vertexer only
-//   Vector<Line> mLines;
-//   Vector<int> mIndexTablesLayer0D;
-//   Vector<int> mIndexTablesLayer2D;
-//   Vector<int> mNFoundLines;
-//   Vector<int> mNExclusiveFoundLines;
-//   Vector<unsigned char> mUsedTracklets;
-//   Vector<float> mXYCentroids;
-//   Vector<float> mZCentroids;
-//   std::array<Vector<int>, 2> mNTrackletsPerClusterD;
-//   std::array<Vector<int>, 3> mXYZHistograms;
-//   Vector<float> mBeamPosition;
-//   Vector<Vertex> mGPUVertices;
-// #ifdef __HIPCC__
-//   Vector<hipcub::KeyValuePair<int, int>> mTmpVertexPositionBins;
-// #else
-//   Vector<cub::KeyValuePair<int, int>> mTmpVertexPositionBins;
-// #endif
-// };
-
-// template <int nLayers>
-// inline Cluster* TimeFrameGPU<nLayers>::getDeviceClustersOnLayer(const int rofId, const int layerId) const
-// {
-//   return getPtrFromRuler<Cluster>(rofId, mClustersD[layerId].get(), mROframesClusters[layerId].data());
-// }
-
-// template <int nLayers>
-// inline unsigned char* TimeFrameGPU<nLayers>::getDeviceUsedClustersOnLayer(const int rofId, const int layerId)
-// {
-//   return getPtrFromRuler<unsigned char>(rofId, mUsedClustersD[layerId].get(), mROframesClusters[layerId].data());
-// }
-
-// template <int nLayers>
-// inline int TimeFrameGPU<nLayers>::getNClustersLayer(const int rofId, const int layerId) const
-// {
-//   return static_cast<int>(mROframesClusters[layerId][rofId + 1] - mROframesClusters[layerId][rofId]);
-// }
-
-// template <int nLayers>
-// inline int* TimeFrameGPU<nLayers>::getDeviceNTrackletsCluster(int rofId, int combId)
-// {
-//   return getPtrFromRuler<int>(rofId, mNTrackletsPerClusterD[combId].get(), mROframesClusters[1].data());
-// }
-
-// template <int nLayers>
-// inline unsigned char* TimeFrameGPU<nLayers>::getDeviceUsedTracklets(const int rofId)
-// {
-//   return getPtrFromRuler<unsigned char>(rofId, mUsedTracklets.get(), mROframesClusters[1].data(), mConfig.maxTrackletsPerCluster);
-// }
-
-// template <int nLayers>
-// inline Line* TimeFrameGPU<nLayers>::getDeviceLines(const int rofId)
-// {
-//   return getPtrFromRuler(rofId, mLines.get(), mROframesClusters[1].data());
-// }
-
-// template <int nLayers>
-// inline Tracklet* TimeFrameGPU<nLayers>::getDeviceTrackletsVertexerOnly(const int rofId, const int layerId)
-// {
-//   return getPtrFromRuler(rofId, mTrackletsD[layerId].get(), mROframesClusters[1].data(), mConfig.maxTrackletsPerCluster);
-// }
-
-// template <int nLayers>
-// inline Tracklet* TimeFrameGPU<nLayers>::getDeviceTracklets(const int rofId, const int layerId)
-// {
-//   return getPtrFromRuler(rofId, mTrackletsD[layerId].get(), mROframesClusters[layerId].data(), mConfig.maxTrackletsPerCluster);
-// }
-
-// template <int nLayers>
-// inline Tracklet* TimeFrameGPU<nLayers>::getDeviceTrackletsAll(const int layerId)
-// {
-//   return mTrackletsD[layerId].get();
-// }
-
-// template <int nLayers>
-// inline Cell* TimeFrameGPU<nLayers>::getDeviceCells(const int layerId)
-// {
-//   return mCellsD[layerId].get();
-// }
-
-// template <int nLayers>
-// inline int* TimeFrameGPU<nLayers>::getDeviceTrackletsLookupTable(const int rofId, const int layerId)
-// {
-//   return getPtrFromRuler(rofId, mTrackletsLookupTablesD[layerId].get(), mROframesClusters[layerId].data());
-// }
-
-// template <int nLayers>
-// inline int* TimeFrameGPU<nLayers>::getDeviceCellsLookupTable(const int layerId)
-// {
-//   return mCellsLookupTablesD[layerId].get();
-// }
-
-// template <int nLayers>
-// inline int* TimeFrameGPU<nLayers>::getDeviceNFoundLines(const int rofId)
-// {
-//   return getPtrFromRuler<int>(rofId, mNFoundLines.get(), mROframesClusters[1].data());
-// }
-
-// template <int nLayers>
-// inline int* TimeFrameGPU<nLayers>::getDeviceExclusiveNFoundLines(const int rofId)
-// {
-//   return getPtrFromRuler<int>(rofId, mNExclusiveFoundLines.get(), mROframesClusters[1].data());
-// }
-
-// template <int nLayers>
-// inline int* TimeFrameGPU<nLayers>::getDeviceCUBBuffer(const size_t rofId)
-// {
-//   return reinterpret_cast<int*>(reinterpret_cast<char*>(mCUBTmpBuffers) + (static_cast<size_t>(rofId * mConfig.tmpCUBBufferSize) & 0xFFFFFFFFFFFFF000));
-// }
-
-// template <int nLayers>
-// inline float* TimeFrameGPU<nLayers>::getDeviceXYCentroids(const int rofId)
-// {
-//   return mXYCentroids.get() + 2 * rofId * mConfig.maxCentroidsXYCapacity;
-// }
-
-// template <int nLayers>
-// inline float* TimeFrameGPU<nLayers>::getDeviceZCentroids(const int rofId)
-// {
-//   return mZCentroids.get() + rofId * mConfig.maxLinesCapacity;
-// }
-
-// template <int nLayers>
-// inline int* TimeFrameGPU<nLayers>::getDeviceXHistograms(const int rofId)
-// {
-//   return mXYZHistograms[0].get() + rofId * mConfig.histConf.nBinsXYZ[0];
-// }
-
-// template <int nLayers>
-// inline int* TimeFrameGPU<nLayers>::getDeviceYHistograms(const int rofId)
-// {
-//   return mXYZHistograms[1].get() + rofId * mConfig.histConf.nBinsXYZ[1];
-// }
-
-// template <int nLayers>
-// inline int* TimeFrameGPU<nLayers>::getDeviceZHistograms(const int rofId)
-// {
-//   return mXYZHistograms[2].get() + rofId * mConfig.histConf.nBinsXYZ[2];
-// }
-
-// template <int nLayers>
-// #ifdef __HIPCC__
-// inline hipcub::KeyValuePair<int, int>* TimeFrameGPU<nLayers>::getTmpVertexPositionBins(const int rofId)
-// #else
-// inline cub::KeyValuePair<int, int>* TimeFrameGPU<nLayers>::getTmpVertexPositionBins(const int rofId)
-// #endif
-// {
-//   return mTmpVertexPositionBins.get() + 3 * rofId;
-// }
-
-// template <int nLayers>
-// inline float* TimeFrameGPU<nLayers>::getDeviceBeamPosition(const int rofId)
-// {
-//   return mBeamPosition.get() + 2 * rofId;
-// }
-
-// template <int nLayers>
-// inline Vertex* TimeFrameGPU<nLayers>::getDeviceVertices(const int rofId)
-// {
-//   return mGPUVertices.get() + rofId * mConfig.maxVerticesCapacity;
-// }
 
 } // namespace gpu
 } // namespace its

--- a/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/TimeFrameGPU.h
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/TimeFrameGPU.h
@@ -137,7 +137,7 @@ class TimeFrameGPU : public TimeFrame
   void initDevice(const int, const IndexTableUtils*, const int);
   void initDevicePartitions(const int, const int);
   template <Task task>
-  void loadPartitionData(const size_t);
+  size_t loadPartitionData(const size_t, const size_t);
   size_t getNPartions() const { return mMemPartitions.size(); }
 
   /// interface
@@ -159,15 +159,16 @@ class TimeFrameGPU : public TimeFrame
 
 template <int nLayers>
 template <Task task>
-void TimeFrameGPU<nLayers>::loadPartitionData(const size_t part)
+size_t TimeFrameGPU<nLayers>::loadPartitionData(const size_t part, const size_t offset) // offset: readout frame to start from 
 {
-  auto startRof = part * GpuTimeFramePartition<nLayers>::computeRofPerPartition(mGpuConfig, mAvailMemGB);
+  auto nRof = GpuTimeFramePartition<nLayers>::computeRofPerPartition(mGpuConfig, mAvailMemGB);
   mMemPartitions[part].reset(GpuTimeFramePartition<nLayers>::computeRofPerPartition(mGpuConfig, mAvailMemGB), task);
   if constexpr ((bool)task) {
     mMemPartitions[part].copyDeviceData(startRof, 3, mGpuStreams[part]);
   } else {
     mMemPartitions[part].copyDeviceData(startRof, nLayers, mGpuStreams[part]);
   }
+  return 
 }
 
 template <int nLayers>

--- a/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/TimeFrameGPU.h
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/TimeFrameGPU.h
@@ -140,6 +140,9 @@ class TimeFrameGPU : public TimeFrame
   void loadPartitionData(const size_t);
   size_t getNPartions() const { return mMemPartitions.size(); }
 
+  /// interface
+  int getNClustersInRofSpan(const int, const int, const int) const;
+
  private:
   bool mInitialised = false;
   std::vector<GpuTimeFramePartition<nLayers>> mMemPartitions;
@@ -165,6 +168,12 @@ void TimeFrameGPU<nLayers>::loadPartitionData(const size_t part)
   } else {
     mMemPartitions[part].copyDeviceData(startRof, nLayers, mGpuStreams[part]);
   }
+}
+
+template <int nLayers>
+inline int TimeFrameGPU<nLayers>::getNClustersInRofSpan(const int rofIdstart, const int rofSpanSize, const int layerId) const
+{
+  return static_cast<int>(mROframesClusters[layerId][(rofIdstart + rofSpanSize) < mROframesClusters.size() ? rofIdstart + rofSpanSize : mROframesClusters.size() - 1] - mROframesClusters[layerId][rofIdstart]);
 }
 
 // #ifdef __HIPCC__

--- a/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/TimeFrameGPU.h
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/TimeFrameGPU.h
@@ -21,8 +21,6 @@
 #include "ITStracking/Configuration.h"
 
 #include "ITStrackingGPU/ClusterLinesGPU.h"
-#include "ITStrackingGPU/Stream.h"
-
 #include "Array.h"
 #include "Vector.h"
 
@@ -35,296 +33,368 @@ namespace o2
 
 namespace its
 {
-using namespace constants::its2;
 
-class TimeFrameGPUConfig;
 namespace gpu
 {
+template <int>
+class StaticTrackingParameters;
+template <int nLayers>
 
-template <int NLayers>
-struct StaticTrackingParameters {
-  StaticTrackingParameters<NLayers>& operator=(const StaticTrackingParameters<NLayers>& t) = default;
-  void set(const TrackingParameters& pars);
-
-  /// General parameters
-  int ClusterSharing = 0;
-  int MinTrackLength = NLayers;
-  float NSigmaCut = 5;
-  float PVres = 1.e-2f;
-  int DeltaROF = 0;
-  int ZBins{256};
-  int PhiBins{128};
-
-  /// Cell finding cuts
-  float CellDeltaTanLambdaSigma = 0.007f;
-};
-
-template <int NLayers>
-void StaticTrackingParameters<NLayers>::set(const TrackingParameters& pars)
+class GpuTimeFramePartition
 {
-  ClusterSharing = pars.ClusterSharing;
-  MinTrackLength = pars.MinTrackLength;
-  NSigmaCut = pars.NSigmaCut;
-  PVres = pars.PVres;
-  DeltaROF = pars.DeltaROF;
-  ZBins = pars.ZBins;
-  PhiBins = pars.PhiBins;
-  CellDeltaTanLambdaSigma = pars.CellDeltaTanLambdaSigma;
-}
-
-template <class T>
-GPUhd() T* getPtrFromRuler(int index, T* src, const int* ruler, const int stride = 1)
-{
-  return src + ruler[index] * stride;
-}
-
-template <class T>
-GPUhd() const T* getPtrFromRuler(int index, const T* src, const int* ruler, const int stride = 1)
-{
-  return src + ruler[index] * stride;
-}
-
-template <int NLayers = 7>
-class TimeFrameGPU : public TimeFrame
-{
-
  public:
-  TimeFrameGPU();
-  ~TimeFrameGPU();
-
-  void checkBufferSizes();
-  void initialise(const int iteration,
-                  const TrackingParameters& trkParam,
-                  const int maxLayers);
-  template <unsigned char isTracker = false>
-  void initialiseDevice(const TrackingParameters&);
-  /// Getters
-  float getDeviceMemory();
-  Cluster* getDeviceClustersOnLayer(const int rofId, const int layerId) const;
-  unsigned char* getDeviceUsedClustersOnLayer(const int rofId, const int layerId);
-  int* getDeviceROframesClustersOnLayer(const int layerId) const { return mROframesClustersD[layerId].get(); }
-  int getNClustersLayer(const int rofId, const int layerId) const;
-  TimeFrameGPUConfig& getConfig() { return mConfig; }
-  gpu::Stream& getStream(const int iLayer) { return mStreamArray[iLayer]; }
-  std::vector<int>& getTrackletSizeHost() { return mTrackletSizeHost; }
-  std::vector<int>& getCellSizeHost() { return mCellSizeHost; }
-
-  // Vertexer only
-  int* getDeviceNTrackletsCluster(int rofId, int combId);
-  int* getDeviceIndexTables(const int layerId) { return mIndexTablesD[layerId].get(); }
-  int* getDeviceIndexTableAtRof(const int layerId, const int rofId) { return mIndexTablesD[layerId].get() + rofId * (ZBins * PhiBins + 1); }
-  unsigned char* getDeviceUsedTracklets(const int rofId);
-  Line* getDeviceLines(const int rofId);
-  Tracklet* getDeviceTrackletsVertexerOnly(const int rofId, const int layerId); // this method uses the cluster table for layer 1 for any layer. It is used for the vertexer only.
-  Tracklet* getDeviceTracklets(const int rofId, const int layerId);
-  Tracklet* getDeviceTrackletsAll(const int layerId);
-  Cell* getDeviceCells(const int layerId);
-  int* getDeviceTrackletsLookupTable(const int rofId, const int layerId);
-  int* getDeviceCellsLookupTable(const int layerId);
-  int* getDeviceNFoundLines(const int rofId);
-  int* getDeviceExclusiveNFoundLines(const int rofId);
-  int* getDeviceCUBBuffer(const size_t rofId);
-  int* getDeviceNFoundTracklets() const { return mDeviceFoundTracklets; };
-  int* getDeviceNFoundCells() const { return mDeviceFoundCells; };
-  float* getDeviceXYCentroids(const int rofId);
-  float* getDeviceZCentroids(const int rofId);
-  int* getDeviceXHistograms(const int rofId);
-  int* getDeviceYHistograms(const int rofId);
-  int* getDeviceZHistograms(const int rofId);
-  gpu::StaticTrackingParameters<NLayers>* getDeviceTrackingParameters() const { return mDeviceTrackingParams; }
-  IndexTableUtils* getDeviceIndexTableUtils() const { return mDeviceIndexTableUtils; }
-
-#ifdef __HIPCC__
-  hipcub::KeyValuePair<int, int>* getTmpVertexPositionBins(const int rofId);
-#else
-  cub::KeyValuePair<int, int>* getTmpVertexPositionBins(const int rofId);
-#endif
-  float* getDeviceBeamPosition(const int rofId);
-  Vertex* getDeviceVertices(const int rofId);
+  GpuTimeFramePartition() = default;
+  ~GpuTimeFramePartition();
+  void initDevice(const size_t, const TimeFrameGPUConfig&);
 
  private:
-  TimeFrameGPUConfig mConfig;
-  std::array<gpu::Stream, NLayers + 1> mStreamArray;
-  std::vector<int> mTrackletSizeHost;
-  std::vector<int> mCellSizeHost;
-  // Per-layer information, do not expand at runtime
-  std::array<Vector<Cluster>, NLayers> mClustersD;
-  std::array<Vector<unsigned char>, NLayers> mUsedClustersD;
-  std::array<Vector<TrackingFrameInfo>, NLayers> mTrackingFrameInfoD;
-  std::array<Vector<int>, NLayers - 1> mIndexTablesD;
-  std::array<Vector<int>, NLayers> mClusterExternalIndicesD;
-  std::array<Vector<Tracklet>, NLayers - 1> mTrackletsD;
-  std::array<Vector<int>, NLayers - 1> mTrackletsLookupTablesD;
-  std::array<Vector<Cell>, NLayers - 2> mCellsD;
-  std::array<Vector<int>, NLayers - 2> mCellsLookupTablesD;
-  std::array<Vector<int>, NLayers> mROframesClustersD; // layers x roframes
-  int* mCUBTmpBuffers;
-  int* mDeviceFoundTracklets;
-  int* mDeviceFoundCells;
-  gpu::StaticTrackingParameters<NLayers>* mDeviceTrackingParams;
-  IndexTableUtils* mDeviceIndexTableUtils;
+  std::array<int*, nLayers> mROframesClustersDevice; // layers x roframes
+  std::array<Cluster*, nLayers> mClustersDevice;
+  std::array<unsigned char*, nLayers> mUsedClustersDevice;
+  std::array<TrackingFrameInfo*, nLayers> mTrackingFrameInfoDevice;
+  std::array<int*, nLayers> mClusterExternalIndicesDevice;
+  std::array<int*, nLayers> mIndexTablesDevice;
+  std::array<Tracklet*, nLayers - 1> mTrackletsDevice;
+  std::array<int*, nLayers - 1> mTrackletsLookupTablesDevice;
+  std::array<Cell*, nLayers - 2> mCellsDevice;
+  std::array<int*, nLayers - 2> mCellsLookupTablesDevice;
 
-  // Vertexer only
-  Vector<Line> mLines;
-  Vector<int> mIndexTablesLayer0D;
-  Vector<int> mIndexTablesLayer2D;
-  Vector<int> mNFoundLines;
-  Vector<int> mNExclusiveFoundLines;
-  Vector<unsigned char> mUsedTracklets;
-  Vector<float> mXYCentroids;
-  Vector<float> mZCentroids;
-  std::array<Vector<int>, 2> mNTrackletsPerClusterD;
-  std::array<Vector<int>, 3> mXYZHistograms;
-  Vector<float> mBeamPosition;
-  Vector<Vertex> mGPUVertices;
-#ifdef __HIPCC__
-  Vector<hipcub::KeyValuePair<int, int>> mTmpVertexPositionBins;
-#else
-  Vector<cub::KeyValuePair<int, int>> mTmpVertexPositionBins;
-#endif
+  int* mCUBTmpBuffers;
+  int* mFoundTrackletsDevice;
+  int* mFoundCellsDevice;
+  IndexTableUtils* mIndexTableUtilsDevice;
+
+  /// Vertexer only
+  Line* mLines;
+  int* mNFoundLines;
+  int* mNExclusiveFoundLines;
+  unsigned char* mUsedTracklets;
+  ///
+
+  size_t mNRof;
 };
 
-template <int NLayers>
-inline Cluster* TimeFrameGPU<NLayers>::getDeviceClustersOnLayer(const int rofId, const int layerId) const
+template <int nLayers = 7>
+class TimeFrameGPU : public TimeFrame
 {
-  return getPtrFromRuler<Cluster>(rofId, mClustersD[layerId].get(), mROframesClusters[layerId].data());
-}
+ public:
+  TimeFrameGPU();
+  void initDevice();
+  void initDevicePartitions(const int nRof)
+  {
+    for (auto* partition : mMemPartitions) {
+      partition->initDevice(nRof, mGpuConfig);
+    }
+  }
 
-template <int NLayers>
-inline unsigned char* TimeFrameGPU<NLayers>::getDeviceUsedClustersOnLayer(const int rofId, const int layerId)
-{
-  return getPtrFromRuler<unsigned char>(rofId, mUsedClustersD[layerId].get(), mROframesClusters[layerId].data());
-}
+ private:
+  std::vector<GpuTimeFramePartition<nLayers>*> mMemPartitions; // Vector of pointers to GPU objects
+  TimeFrameGPUConfig mGpuConfig;
 
-template <int NLayers>
-inline int TimeFrameGPU<NLayers>::getNClustersLayer(const int rofId, const int layerId) const
-{
-  return static_cast<int>(mROframesClusters[layerId][rofId + 1] - mROframesClusters[layerId][rofId]);
-}
+  // Device pointers
+  gpu::StaticTrackingParameters<nLayers>* mTrackingParamsDevice;
+};
 
-template <int NLayers>
-inline int* TimeFrameGPU<NLayers>::getDeviceNTrackletsCluster(int rofId, int combId)
-{
-  return getPtrFromRuler<int>(rofId, mNTrackletsPerClusterD[combId].get(), mROframesClusters[1].data());
-}
+// #ifdef __HIPCC__
+// #include <hip/hip_runtime.h>
+// #endif
 
-template <int NLayers>
-inline unsigned char* TimeFrameGPU<NLayers>::getDeviceUsedTracklets(const int rofId)
-{
-  return getPtrFromRuler<unsigned char>(rofId, mUsedTracklets.get(), mROframesClusters[1].data(), mConfig.maxTrackletsPerCluster);
-}
+// #include "ITStracking/TimeFrame.h"
+// #include "ITStracking/Configuration.h"
 
-template <int NLayers>
-inline Line* TimeFrameGPU<NLayers>::getDeviceLines(const int rofId)
-{
-  return getPtrFromRuler(rofId, mLines.get(), mROframesClusters[1].data());
-}
+// #include "ITStrackingGPU/ClusterLinesGPU.h"
+// #include "ITStrackingGPU/Stream.h"
 
-template <int NLayers>
-inline Tracklet* TimeFrameGPU<NLayers>::getDeviceTrackletsVertexerOnly(const int rofId, const int layerId)
-{
-  return getPtrFromRuler(rofId, mTrackletsD[layerId].get(), mROframesClusters[1].data(), mConfig.maxTrackletsPerCluster);
-}
+// #include "Array.h"
+// #include "Vector.h"
 
-template <int NLayers>
-inline Tracklet* TimeFrameGPU<NLayers>::getDeviceTracklets(const int rofId, const int layerId)
-{
-  return getPtrFromRuler(rofId, mTrackletsD[layerId].get(), mROframesClusters[layerId].data(), mConfig.maxTrackletsPerCluster);
-}
+// #include "GPUCommonDef.h"
+// #include "GPUCommonMath.h"
+// #include "GPUCommonLogger.h"
 
-template <int NLayers>
-inline Tracklet* TimeFrameGPU<NLayers>::getDeviceTrackletsAll(const int layerId)
-{
-  return mTrackletsD[layerId].get();
-}
+// namespace o2
+// {
 
-template <int NLayers>
-inline Cell* TimeFrameGPU<NLayers>::getDeviceCells(const int layerId)
-{
-  return mCellsD[layerId].get();
-}
+// namespace its
+// {
+// using namespace constants::its2;
 
-template <int NLayers>
-inline int* TimeFrameGPU<NLayers>::getDeviceTrackletsLookupTable(const int rofId, const int layerId)
-{
-  return getPtrFromRuler(rofId, mTrackletsLookupTablesD[layerId].get(), mROframesClusters[layerId].data());
-}
+// class TimeFrameGPUConfig;
+// namespace gpu
+// {
 
-template <int NLayers>
-inline int* TimeFrameGPU<NLayers>::getDeviceCellsLookupTable(const int layerId)
-{
-  return mCellsLookupTablesD[layerId].get();
-}
+// template <int nLayers>
+// struct StaticTrackingParameters {
+//   StaticTrackingParameters<nLayers>& operator=(const StaticTrackingParameters<nLayers>& t) = default;
+//   void set(const TrackingParameters& pars);
 
-template <int NLayers>
-inline int* TimeFrameGPU<NLayers>::getDeviceNFoundLines(const int rofId)
-{
-  return getPtrFromRuler<int>(rofId, mNFoundLines.get(), mROframesClusters[1].data());
-}
+//   /// General parameters
+//   int ClusterSharing = 0;
+//   int MinTrackLength = nLayers;
+//   float NSigmaCut = 5;
+//   float PVres = 1.e-2f;
+//   int DeltaROF = 0;
+//   int ZBins{256};
+//   int PhiBins{128};
 
-template <int NLayers>
-inline int* TimeFrameGPU<NLayers>::getDeviceExclusiveNFoundLines(const int rofId)
-{
-  return getPtrFromRuler<int>(rofId, mNExclusiveFoundLines.get(), mROframesClusters[1].data());
-}
+//   /// Cell finding cuts
+//   float CellDeltaTanLambdaSigma = 0.007f;
+// };
 
-template <int NLayers>
-inline int* TimeFrameGPU<NLayers>::getDeviceCUBBuffer(const size_t rofId)
-{
-  return reinterpret_cast<int*>(reinterpret_cast<char*>(mCUBTmpBuffers) + (static_cast<size_t>(rofId * mConfig.tmpCUBBufferSize) & 0xFFFFFFFFFFFFF000));
-}
+// template <int nLayers>
+// void StaticTrackingParameters<nLayers>::set(const TrackingParameters& pars)
+// {
+//   ClusterSharing = pars.ClusterSharing;
+//   MinTrackLength = pars.MinTrackLength;
+//   NSigmaCut = pars.NSigmaCut;
+//   PVres = pars.PVres;
+//   DeltaROF = pars.DeltaROF;
+//   ZBins = pars.ZBins;
+//   PhiBins = pars.PhiBins;
+//   CellDeltaTanLambdaSigma = pars.CellDeltaTanLambdaSigma;
+// }
 
-template <int NLayers>
-inline float* TimeFrameGPU<NLayers>::getDeviceXYCentroids(const int rofId)
-{
-  return mXYCentroids.get() + 2 * rofId * mConfig.maxCentroidsXYCapacity;
-}
+// template <int nLayers = 7>
+// class TimeFrameGPU : public TimeFrame
+// {
 
-template <int NLayers>
-inline float* TimeFrameGPU<NLayers>::getDeviceZCentroids(const int rofId)
-{
-  return mZCentroids.get() + rofId * mConfig.maxLinesCapacity;
-}
+//  public:
+//   TimeFrameGPU();
+//   ~TimeFrameGPU();
 
-template <int NLayers>
-inline int* TimeFrameGPU<NLayers>::getDeviceXHistograms(const int rofId)
-{
-  return mXYZHistograms[0].get() + rofId * mConfig.histConf.nBinsXYZ[0];
-}
+//   void checkBufferSizes();
+//   void initialise(const int iteration,
+//                   const TrackingParameters& trkParam,
+//                   const int maxLayers);
+//   template <unsigned char isTracker = false>
+//   void initialiseDevice(const TrackingParameters&);
+//   /// Getters
+//   float getDeviceMemory();
+//   Cluster* getDeviceClustersOnLayer(const int rofId, const int layerId) const;
+//   unsigned char* getDeviceUsedClustersOnLayer(const int rofId, const int layerId);
+//   int* getDeviceROframesClustersOnLayer(const int layerId) const { return mROframesClustersD[layerId].get(); }
+//   int getNClustersLayer(const int rofId, const int layerId) const;
+//   TimeFrameGPUConfig& getConfig() { return mConfig; }
+//   gpu::Stream& getStream(const int iLayer) { return mStreamArray[iLayer]; }
+//   std::vector<int>& getTrackletSizeHost() { return mTrackletSizeHost; }
+//   std::vector<int>& getCellSizeHost() { return mCellSizeHost; }
 
-template <int NLayers>
-inline int* TimeFrameGPU<NLayers>::getDeviceYHistograms(const int rofId)
-{
-  return mXYZHistograms[1].get() + rofId * mConfig.histConf.nBinsXYZ[1];
-}
+//   // Vertexer only
+//   int* getDeviceNTrackletsCluster(int rofId, int combId);
+//   int* getDeviceIndexTables(const int layerId) { return mIndexTablesD[layerId].get(); }
+//   int* getDeviceIndexTableAtRof(const int layerId, const int rofId) { return mIndexTablesD[layerId].get() + rofId * (ZBins * PhiBins + 1); }
+//   unsigned char* getDeviceUsedTracklets(const int rofId);
+//   Line* getDeviceLines(const int rofId);
+//   Tracklet* getDeviceTrackletsVertexerOnly(const int rofId, const int layerId); // this method uses the cluster table for layer 1 for any layer. It is used for the vertexer only.
+//   Tracklet* getDeviceTracklets(const int rofId, const int layerId);
+//   Tracklet* getDeviceTrackletsAll(const int layerId);
+//   Cell* getDeviceCells(const int layerId);
+//   int* getDeviceTrackletsLookupTable(const int rofId, const int layerId);
+//   int* getDeviceCellsLookupTable(const int layerId);
+//   int* getDeviceNFoundLines(const int rofId);
+//   int* getDeviceExclusiveNFoundLines(const int rofId);
+//   int* getDeviceCUBBuffer(const size_t rofId);
+//   int* getDeviceNFoundTracklets() const { return mDeviceFoundTracklets; };
+//   int* getDeviceNFoundCells() const { return mDeviceFoundCells; };
+//   float* getDeviceXYCentroids(const int rofId);
+//   float* getDeviceZCentroids(const int rofId);
+//   int* getDeviceXHistograms(const int rofId);
+//   int* getDeviceYHistograms(const int rofId);
+//   int* getDeviceZHistograms(const int rofId);
+//   gpu::StaticTrackingParameters<nLayers>* getDeviceTrackingParameters() const { return mDeviceTrackingParams; }
+//   IndexTableUtils* getDeviceIndexTableUtils() const { return mDeviceIndexTableUtils; }
 
-template <int NLayers>
-inline int* TimeFrameGPU<NLayers>::getDeviceZHistograms(const int rofId)
-{
-  return mXYZHistograms[2].get() + rofId * mConfig.histConf.nBinsXYZ[2];
-}
+// #ifdef __HIPCC__
+//   hipcub::KeyValuePair<int, int>* getTmpVertexPositionBins(const int rofId);
+// #else
+//   cub::KeyValuePair<int, int>* getTmpVertexPositionBins(const int rofId);
+// #endif
+//   float* getDeviceBeamPosition(const int rofId);
+//   Vertex* getDeviceVertices(const int rofId);
 
-template <int NLayers>
-#ifdef __HIPCC__
-inline hipcub::KeyValuePair<int, int>* TimeFrameGPU<NLayers>::getTmpVertexPositionBins(const int rofId)
-#else
-inline cub::KeyValuePair<int, int>* TimeFrameGPU<NLayers>::getTmpVertexPositionBins(const int rofId)
-#endif
-{
-  return mTmpVertexPositionBins.get() + 3 * rofId;
-}
+//  private:
+//   TimeFrameGPUConfig mConfig;
+//   std::array<gpu::Stream, nLayers + 1> mStreamArray;
+//   std::vector<int> mTrackletSizeHost;
+//   std::vector<int> mCellSizeHost;
+//   // Per-layer information, do not expand at runtime
+//   std::array<Vector<Cluster>, nLayers> mClustersD;
+//   std::array<Vector<unsigned char>, nLayers> mUsedClustersD;
+//   std::array<Vector<TrackingFrameInfo>, nLayers> mTrackingFrameInfoD;
+//   std::array<Vector<int>, nLayers - 1> mIndexTablesD;
+//   std::array<Vector<int>, nLayers> mClusterExternalIndicesD;
+//   std::array<Vector<Tracklet>, nLayers - 1> mTrackletsD;
+//   std::array<Vector<int>, nLayers - 1> mTrackletsLookupTablesD;
+//   std::array<Vector<Cell>, nLayers - 2> mCellsD;
+//   std::array<Vector<int>, nLayers - 2> mCellsLookupTablesD;
+//   std::array<Vector<int>, nLayers> mROframesClustersD; // layers x roframes
+//   int* mCUBTmpBuffers;
+//   int* mDeviceFoundTracklets;
+//   int* mDeviceFoundCells;
+//   gpu::StaticTrackingParameters<nLayers>* mDeviceTrackingParams;
+//   IndexTableUtils* mDeviceIndexTableUtils;
 
-template <int NLayers>
-inline float* TimeFrameGPU<NLayers>::getDeviceBeamPosition(const int rofId)
-{
-  return mBeamPosition.get() + 2 * rofId;
-}
+//   // Vertexer only
+//   Vector<Line> mLines;
+//   Vector<int> mIndexTablesLayer0D;
+//   Vector<int> mIndexTablesLayer2D;
+//   Vector<int> mNFoundLines;
+//   Vector<int> mNExclusiveFoundLines;
+//   Vector<unsigned char> mUsedTracklets;
+//   Vector<float> mXYCentroids;
+//   Vector<float> mZCentroids;
+//   std::array<Vector<int>, 2> mNTrackletsPerClusterD;
+//   std::array<Vector<int>, 3> mXYZHistograms;
+//   Vector<float> mBeamPosition;
+//   Vector<Vertex> mGPUVertices;
+// #ifdef __HIPCC__
+//   Vector<hipcub::KeyValuePair<int, int>> mTmpVertexPositionBins;
+// #else
+//   Vector<cub::KeyValuePair<int, int>> mTmpVertexPositionBins;
+// #endif
+// };
 
-template <int NLayers>
-inline Vertex* TimeFrameGPU<NLayers>::getDeviceVertices(const int rofId)
-{
-  return mGPUVertices.get() + rofId * mConfig.maxVerticesCapacity;
-}
+// template <int nLayers>
+// inline Cluster* TimeFrameGPU<nLayers>::getDeviceClustersOnLayer(const int rofId, const int layerId) const
+// {
+//   return getPtrFromRuler<Cluster>(rofId, mClustersD[layerId].get(), mROframesClusters[layerId].data());
+// }
+
+// template <int nLayers>
+// inline unsigned char* TimeFrameGPU<nLayers>::getDeviceUsedClustersOnLayer(const int rofId, const int layerId)
+// {
+//   return getPtrFromRuler<unsigned char>(rofId, mUsedClustersD[layerId].get(), mROframesClusters[layerId].data());
+// }
+
+// template <int nLayers>
+// inline int TimeFrameGPU<nLayers>::getNClustersLayer(const int rofId, const int layerId) const
+// {
+//   return static_cast<int>(mROframesClusters[layerId][rofId + 1] - mROframesClusters[layerId][rofId]);
+// }
+
+// template <int nLayers>
+// inline int* TimeFrameGPU<nLayers>::getDeviceNTrackletsCluster(int rofId, int combId)
+// {
+//   return getPtrFromRuler<int>(rofId, mNTrackletsPerClusterD[combId].get(), mROframesClusters[1].data());
+// }
+
+// template <int nLayers>
+// inline unsigned char* TimeFrameGPU<nLayers>::getDeviceUsedTracklets(const int rofId)
+// {
+//   return getPtrFromRuler<unsigned char>(rofId, mUsedTracklets.get(), mROframesClusters[1].data(), mConfig.maxTrackletsPerCluster);
+// }
+
+// template <int nLayers>
+// inline Line* TimeFrameGPU<nLayers>::getDeviceLines(const int rofId)
+// {
+//   return getPtrFromRuler(rofId, mLines.get(), mROframesClusters[1].data());
+// }
+
+// template <int nLayers>
+// inline Tracklet* TimeFrameGPU<nLayers>::getDeviceTrackletsVertexerOnly(const int rofId, const int layerId)
+// {
+//   return getPtrFromRuler(rofId, mTrackletsD[layerId].get(), mROframesClusters[1].data(), mConfig.maxTrackletsPerCluster);
+// }
+
+// template <int nLayers>
+// inline Tracklet* TimeFrameGPU<nLayers>::getDeviceTracklets(const int rofId, const int layerId)
+// {
+//   return getPtrFromRuler(rofId, mTrackletsD[layerId].get(), mROframesClusters[layerId].data(), mConfig.maxTrackletsPerCluster);
+// }
+
+// template <int nLayers>
+// inline Tracklet* TimeFrameGPU<nLayers>::getDeviceTrackletsAll(const int layerId)
+// {
+//   return mTrackletsD[layerId].get();
+// }
+
+// template <int nLayers>
+// inline Cell* TimeFrameGPU<nLayers>::getDeviceCells(const int layerId)
+// {
+//   return mCellsD[layerId].get();
+// }
+
+// template <int nLayers>
+// inline int* TimeFrameGPU<nLayers>::getDeviceTrackletsLookupTable(const int rofId, const int layerId)
+// {
+//   return getPtrFromRuler(rofId, mTrackletsLookupTablesD[layerId].get(), mROframesClusters[layerId].data());
+// }
+
+// template <int nLayers>
+// inline int* TimeFrameGPU<nLayers>::getDeviceCellsLookupTable(const int layerId)
+// {
+//   return mCellsLookupTablesD[layerId].get();
+// }
+
+// template <int nLayers>
+// inline int* TimeFrameGPU<nLayers>::getDeviceNFoundLines(const int rofId)
+// {
+//   return getPtrFromRuler<int>(rofId, mNFoundLines.get(), mROframesClusters[1].data());
+// }
+
+// template <int nLayers>
+// inline int* TimeFrameGPU<nLayers>::getDeviceExclusiveNFoundLines(const int rofId)
+// {
+//   return getPtrFromRuler<int>(rofId, mNExclusiveFoundLines.get(), mROframesClusters[1].data());
+// }
+
+// template <int nLayers>
+// inline int* TimeFrameGPU<nLayers>::getDeviceCUBBuffer(const size_t rofId)
+// {
+//   return reinterpret_cast<int*>(reinterpret_cast<char*>(mCUBTmpBuffers) + (static_cast<size_t>(rofId * mConfig.tmpCUBBufferSize) & 0xFFFFFFFFFFFFF000));
+// }
+
+// template <int nLayers>
+// inline float* TimeFrameGPU<nLayers>::getDeviceXYCentroids(const int rofId)
+// {
+//   return mXYCentroids.get() + 2 * rofId * mConfig.maxCentroidsXYCapacity;
+// }
+
+// template <int nLayers>
+// inline float* TimeFrameGPU<nLayers>::getDeviceZCentroids(const int rofId)
+// {
+//   return mZCentroids.get() + rofId * mConfig.maxLinesCapacity;
+// }
+
+// template <int nLayers>
+// inline int* TimeFrameGPU<nLayers>::getDeviceXHistograms(const int rofId)
+// {
+//   return mXYZHistograms[0].get() + rofId * mConfig.histConf.nBinsXYZ[0];
+// }
+
+// template <int nLayers>
+// inline int* TimeFrameGPU<nLayers>::getDeviceYHistograms(const int rofId)
+// {
+//   return mXYZHistograms[1].get() + rofId * mConfig.histConf.nBinsXYZ[1];
+// }
+
+// template <int nLayers>
+// inline int* TimeFrameGPU<nLayers>::getDeviceZHistograms(const int rofId)
+// {
+//   return mXYZHistograms[2].get() + rofId * mConfig.histConf.nBinsXYZ[2];
+// }
+
+// template <int nLayers>
+// #ifdef __HIPCC__
+// inline hipcub::KeyValuePair<int, int>* TimeFrameGPU<nLayers>::getTmpVertexPositionBins(const int rofId)
+// #else
+// inline cub::KeyValuePair<int, int>* TimeFrameGPU<nLayers>::getTmpVertexPositionBins(const int rofId)
+// #endif
+// {
+//   return mTmpVertexPositionBins.get() + 3 * rofId;
+// }
+
+// template <int nLayers>
+// inline float* TimeFrameGPU<nLayers>::getDeviceBeamPosition(const int rofId)
+// {
+//   return mBeamPosition.get() + 2 * rofId;
+// }
+
+// template <int nLayers>
+// inline Vertex* TimeFrameGPU<nLayers>::getDeviceVertices(const int rofId)
+// {
+//   return mGPUVertices.get() + rofId * mConfig.maxVerticesCapacity;
+// }
 
 } // namespace gpu
 } // namespace its

--- a/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/TimeFrameGPU.h
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/TimeFrameGPU.h
@@ -208,7 +208,7 @@ size_t TimeFrameGPU<nLayers>::loadChunkData(const size_t chunk, const size_t off
   } else {
     nRof = mMemChunks[chunk].loadDataOnDevice(offset, nLayers, mGpuStreams[chunk]);
   }
-  LOGP(debug, "In chunk {}: loaded {} readout frames starting from {}", chunk, nRof, offset);
+  LOGP(info, "In chunk {}: loaded {} readout frames starting from {}", chunk, nRof, offset);
   return nRof;
 }
 

--- a/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/TimeFrameGPU.h
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/TimeFrameGPU.h
@@ -93,8 +93,6 @@ class GpuTimeFrameChunk
  private:
   /// Host
   std::array<gsl::span<const Cluster>, nLayers> mHostClusters;
-  std::array<gsl::span<const int>, nLayers> mHostNClustersROF;
-  std::array<gsl::span<const int>, nLayers> mHostROframesClusters;
   std::array<gsl::span<const int>, nLayers> mHostIndexTables;
 
   /// Device

--- a/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/TimeFrameGPU.h
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/TimeFrameGPU.h
@@ -118,6 +118,7 @@ class GpuTimeFrameChunk
   int* getDeviceNFoundLines() { return mNFoundLinesDevice; }
   int* getDeviceNExclusiveFoundLines() { return mNExclusiveFoundLinesDevice; }
   unsigned char* getDeviceUsedTracklets() { return mUsedTrackletsDevice; }
+  int* getDeviceClusteredLines() { return mClusteredLinesDevice; }
 
  private:
   /// Host
@@ -145,6 +146,7 @@ class GpuTimeFrameChunk
   int* mNExclusiveFoundLinesDevice;
   unsigned char* mUsedTrackletsDevice;
   std::array<int*, 2> mNTrackletsPerClusterDevice;
+  int* mClusteredLinesDevice;
 
   /// State and configuration
   bool mAllocated = false;
@@ -208,7 +210,7 @@ size_t TimeFrameGPU<nLayers>::loadChunkData(const size_t chunk, const size_t off
   } else {
     nRof = mMemChunks[chunk].loadDataOnDevice(offset, nLayers, mGpuStreams[chunk]);
   }
-  LOGP(info, "In chunk {}: loaded {} readout frames starting from {}", chunk, nRof, offset);
+  LOGP(debug, "In chunk {}: loaded {} readout frames starting from {}", chunk, nRof, offset);
   return nRof;
 }
 

--- a/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/TimeFrameGPU.h
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/TimeFrameGPU.h
@@ -69,7 +69,7 @@ class GpuTimeFramePartition
   size_t copyDeviceData(const size_t, const int, Stream&);
 
   /// Interface
-  int* getDeviceROframesClusters(const int);
+  int* getDeviceNClustersROF(const int);
   Cluster* getDeviceClusters(const int);
   unsigned char* getDeviceUsedClusters(const int);
   TrackingFrameInfo* getDeviceTrackingFrameInfo(const int);
@@ -83,7 +83,6 @@ class GpuTimeFramePartition
   int* getDeviceCUBTmpBuffers() { return mCUBTmpBufferDevice; }
   int* getDeviceFoundTracklets() { return mFoundTrackletsDevice; }
   int* getDeviceFoundCells() { return mFoundCellsDevice; }
-  IndexTableUtils* getDeviceIndexTableUtils() { return mIndexTableUtilsDevice; }
 
   /// Vertexer only
   int* getDeviceNTrackletCluster(const int combid) { return mNTrackletsPerClusterDevice[combid]; }
@@ -94,10 +93,13 @@ class GpuTimeFramePartition
 
   /// Host
   std::array<gsl::span<const Cluster>, nLayers> mHostClusters;
+  std::array<gsl::span<const int>, nLayers> mHostNClustersROF;
   std::array<gsl::span<const int>, nLayers> mHostROframesClusters;
+  std::array<gsl::span<const int>, nLayers> mHostIndexTables;
 
   /// Device
-  std::array<int*, nLayers> mROframesClustersDevice; // layers x roframes
+  std::array<int*, nLayers> mNClustersROFDevice; // layers x roframes
+  std::array<int*, nLayers> mROframesClustersDevice;
   std::array<Cluster*, nLayers> mClustersDevice;
 
  private:
@@ -113,7 +115,6 @@ class GpuTimeFramePartition
   int* mCUBTmpBufferDevice;
   int* mFoundTrackletsDevice;
   int* mFoundCellsDevice;
-  IndexTableUtils* mIndexTableUtilsDevice;
 
   /// Vertexer only
   Line* mLinesDevice;
@@ -150,6 +151,7 @@ class TimeFrameGPU : public TimeFrame
 
   /// interface
   int getNClustersInRofSpan(const int, const int, const int) const;
+  IndexTableUtils* getDeviceIndexTableUtils() { return mIndexTableUtilsDevice; }
 
  private:
   bool mDeviceInitialised = false;
@@ -159,11 +161,11 @@ class TimeFrameGPU : public TimeFrame
 
   // Device pointers
   StaticTrackingParameters<nLayers>* mTrackingParamsDevice;
-  IndexTableUtils* mDeviceIndexTableUtils;
+  IndexTableUtils* mIndexTableUtilsDevice;
 
   // State
   std::vector<Stream> mGpuStreams;
-  size_t mAvailMemGB; //
+  size_t mAvailMemGB;
 };
 
 template <int nLayers>

--- a/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/TracerGPU.h
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/TracerGPU.h
@@ -27,7 +27,7 @@ class Tracer
 } // namespace gpu
 } // namespace its
 } // namespace o2
-#define RANGE(name, cid) Tracer tracer(name, cid);
+#define RANGE(name, cid) o2::its::gpu::Tracer tracer(name, cid);
 #else
 #define RANGE(name, cid)
 #endif

--- a/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/TracerGPU.h
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/TracerGPU.h
@@ -1,0 +1,33 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+///
+#include "ITStracking/Definitions.h"
+
+#if defined(__CUDACC__) && defined(__USE_GPU_TRACER__)
+namespace o2
+{
+namespace its
+{
+namespace gpu
+{
+class Tracer
+{
+ public:
+  Tracer(const char* name, int color_id = 0);
+  ~Tracer();
+};
+} // namespace gpu
+} // namespace its
+} // namespace o2
+#define RANGE(name, cid) Tracer tracer(name, cid);
+#else
+#define RANGE(name, cid)
+#endif

--- a/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/Utils.h
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/Utils.h
@@ -41,15 +41,15 @@ GPUh() void gpuThrowOnError();
 
 namespace utils
 {
-namespace host
-{
-
 #ifdef __CUDACC__
 void checkGPUError(const cudaError_t error, const char* file = __FILE__, const int line = __LINE__);
 #endif
 #ifdef __HIPCC__
 void checkGPUError(const hipError_t error, const char* file = __FILE__, const int line = __LINE__);
 #endif
+
+// Dump device properties
+void getDeviceProp(int, bool verbose = true);
 
 dim3 getBlockSize(const int);
 dim3 getBlockSize(const int, const int);
@@ -64,13 +64,9 @@ void gpuMemcpyHostToDevice(void*, const void*, int);
 void gpuMemcpyDeviceToHost(void*, const void*, int);
 void gpuMemcpyToSymbol(const void* symbol, const void* src, int size);
 void gpuMemcpyFromSymbol(void* dst, const void* symbol, int size);
-} // namespace host
 
-namespace device
-{
 GPUd() int getLaneIndex();
 GPUd() int shareToWarp(const int, const int);
-} // namespace device
 } // namespace utils
 } // namespace gpu
 } // namespace its

--- a/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/Utils.h
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/Utils.h
@@ -25,16 +25,30 @@ namespace its
 {
 namespace gpu
 {
+template <class T>
+GPUhd() T* getPtrFromRuler(int index, T* src, const int* ruler, const int stride = 1)
+{
+  return src + ruler[index] * stride;
+}
+
+template <class T>
+GPUhd() const T* getPtrFromRuler(int index, const T* src, const int* ruler, const int stride = 1)
+{
+  return src + ruler[index] * stride;
+}
+
+GPUh() void gpuThrowOnError();
+
 namespace utils
 {
 namespace host
 {
 
 #ifdef __CUDACC__
-void checkGPUError(const cudaError_t error, const char* file, const int line);
+void checkGPUError(const cudaError_t error, const char* file = __FILE__, const int line = __LINE__);
 #endif
 #ifdef __HIPCC__
-void checkGPUError(const hipError_t error, const char* file, const int line);
+void checkGPUError(const hipError_t error, const char* file = __FILE__, const int line = __LINE__);
 #endif
 
 dim3 getBlockSize(const int);

--- a/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/Vector.h
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/Vector.h
@@ -100,17 +100,17 @@ Vector<T>::Vector(const T* const source, const size_t size, const size_t initial
   if (size > 0) {
     try {
 
-      utils::host::gpuMalloc(reinterpret_cast<void**>(&mArrayPtr), size * sizeof(T));
-      utils::host::gpuMalloc(reinterpret_cast<void**>(&mDeviceSizePtr), sizeof(size_t));
+      utils::gpuMalloc(reinterpret_cast<void**>(&mArrayPtr), size * sizeof(T));
+      utils::gpuMalloc(reinterpret_cast<void**>(&mDeviceSizePtr), sizeof(size_t));
 
       if (source != nullptr) {
 
-        utils::host::gpuMemcpyHostToDevice(mArrayPtr, source, size * sizeof(T));
-        utils::host::gpuMemcpyHostToDevice(mDeviceSizePtr, &size, sizeof(size_t));
+        utils::gpuMemcpyHostToDevice(mArrayPtr, source, size * sizeof(T));
+        utils::gpuMemcpyHostToDevice(mDeviceSizePtr, &size, sizeof(size_t));
 
       } else {
 
-        utils::host::gpuMemcpyHostToDevice(mDeviceSizePtr, &initialSize, sizeof(size_t));
+        utils::gpuMemcpyHostToDevice(mDeviceSizePtr, &initialSize, sizeof(size_t));
       }
 
     } catch (...) {
@@ -177,7 +177,7 @@ template <typename T>
 size_t Vector<T>::getSizeFromDevice() const
 {
   size_t size;
-  utils::host::gpuMemcpyDeviceToHost(&size, mDeviceSizePtr, sizeof(size_t));
+  utils::gpuMemcpyDeviceToHost(&size, mDeviceSizePtr, sizeof(size_t));
 
   return size;
 }
@@ -185,7 +185,7 @@ size_t Vector<T>::getSizeFromDevice() const
 template <typename T>
 void Vector<T>::resize(const size_t size)
 {
-  utils::host::gpuMemcpyHostToDevice(mDeviceSizePtr, &size, sizeof(size_t));
+  utils::gpuMemcpyHostToDevice(mDeviceSizePtr, &size, sizeof(size_t));
 }
 
 template <typename T>
@@ -199,20 +199,20 @@ void Vector<T>::reset(const T* const source, const size_t size, const size_t ini
 {
   if (size > mCapacity) {
     if (mArrayPtr != nullptr) {
-      utils::host::gpuFree(mArrayPtr);
+      utils::gpuFree(mArrayPtr);
     }
-    utils::host::gpuMalloc(reinterpret_cast<void**>(&mArrayPtr), size * sizeof(T));
+    utils::gpuMalloc(reinterpret_cast<void**>(&mArrayPtr), size * sizeof(T));
     mCapacity = size;
   }
   if (mDeviceSizePtr == nullptr) {
-    utils::host::gpuMalloc(reinterpret_cast<void**>(&mDeviceSizePtr), sizeof(size_t));
+    utils::gpuMalloc(reinterpret_cast<void**>(&mDeviceSizePtr), sizeof(size_t));
   }
 
   if (source != nullptr) {
-    utils::host::gpuMemcpyHostToDevice(mArrayPtr, source, size * sizeof(T));
-    utils::host::gpuMemcpyHostToDevice(mDeviceSizePtr, &size, sizeof(size_t));
+    utils::gpuMemcpyHostToDevice(mArrayPtr, source, size * sizeof(T));
+    utils::gpuMemcpyHostToDevice(mDeviceSizePtr, &size, sizeof(size_t));
   } else {
-    utils::host::gpuMemcpyHostToDevice(mDeviceSizePtr, &initialSize, sizeof(size_t));
+    utils::gpuMemcpyHostToDevice(mDeviceSizePtr, &initialSize, sizeof(size_t));
   }
 }
 
@@ -221,33 +221,33 @@ void Vector<T>::resetWithInt(const size_t size, const int value)
 {
   if (size > mCapacity) {
     if (mArrayPtr != nullptr) {
-      utils::host::gpuFree(mArrayPtr);
+      utils::gpuFree(mArrayPtr);
     }
-    utils::host::gpuMalloc(reinterpret_cast<void**>(&mArrayPtr), size * sizeof(int));
+    utils::gpuMalloc(reinterpret_cast<void**>(&mArrayPtr), size * sizeof(int));
     mCapacity = size;
   }
   if (mDeviceSizePtr == nullptr) {
-    utils::host::gpuMalloc(reinterpret_cast<void**>(&mDeviceSizePtr), sizeof(int));
+    utils::gpuMalloc(reinterpret_cast<void**>(&mDeviceSizePtr), sizeof(int));
   }
 
-  utils::host::gpuMemset(mArrayPtr, value, size * sizeof(int));
-  utils::host::gpuMemcpyHostToDevice(mDeviceSizePtr, &size, sizeof(int));
+  utils::gpuMemset(mArrayPtr, value, size * sizeof(int));
+  utils::gpuMemcpyHostToDevice(mDeviceSizePtr, &size, sizeof(int));
 }
 
 template <typename T>
 void Vector<T>::copyIntoSizedVector(std::vector<T>& destinationVector)
 {
-  utils::host::gpuMemcpyDeviceToHost(destinationVector.data(), mArrayPtr, destinationVector.size() * sizeof(T));
+  utils::gpuMemcpyDeviceToHost(destinationVector.data(), mArrayPtr, destinationVector.size() * sizeof(T));
 }
 
 template <typename T>
 inline void Vector<T>::destroy()
 {
   if (mArrayPtr != nullptr) {
-    utils::host::gpuFree(mArrayPtr);
+    utils::gpuFree(mArrayPtr);
   }
   if (mDeviceSizePtr != nullptr) {
-    utils::host::gpuFree(mDeviceSizePtr);
+    utils::gpuFree(mDeviceSizePtr);
   }
 }
 
@@ -279,7 +279,7 @@ template <typename T>
 GPUh() T Vector<T>::getElementFromDevice(const size_t index) const
 {
   T element;
-  utils::host::gpuMemcpyDeviceToHost(&element, mArrayPtr + index, sizeof(T));
+  utils::gpuMemcpyDeviceToHost(&element, mArrayPtr + index, sizeof(T));
 
   return element;
 }

--- a/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/VertexerTraitsGPU.h
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/ITStrackingGPU/VertexerTraitsGPU.h
@@ -21,6 +21,7 @@
 #include <array>
 
 #include "ITStracking/VertexerTraits.h"
+#include "ITStracking/Configuration.h"
 #include "ITStracking/Cluster.h"
 #include "ITStracking/Constants.h"
 #include "ITStracking/Definitions.h"

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/CMakeLists.txt
@@ -11,20 +11,24 @@
 
 # CUDA
 if(CUDA_ENABLED)
-
+find_package(CUDAToolkit)
+# message(FATAL_ERROR "${CUDAToolkit_FOUND}")
 message(STATUS "Building ITS CUDA tracker")
+
 o2_add_library(ITStrackingCUDA
                SOURCES ClusterLinesGPU.cu
                        Context.cu
                        Stream.cu
                        TrackerTraitsGPU.cu
                        TimeFrameGPU.cu
+                       TracerGPU.cu
                        VertexerTraitsGPU.cu
                        Utils.cu
                PUBLIC_INCLUDE_DIRECTORIES ../
                PUBLIC_LINK_LIBRARIES O2::ITStracking
                                      O2::SimConfig
                                      O2::SimulationDataFormat
+                                     CUDA::nvToolsExt # TODO: change to CUDA::nvtx3 when CMake bump >= 3.25  
                TARGETVARNAME targetName)
 
 set_property(TARGET ${targetName} PROPERTY CUDA_SEPARABLE_COMPILATION ON)

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/ClusterLinesGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/ClusterLinesGPU.cu
@@ -30,11 +30,11 @@ GPUd() ClusterLinesGPU::ClusterLinesGPU(const Line& firstLine, const Line& secon
     covarianceSecond[i] = 1.f;
   }
 
-  float determinantFirst =
+  double determinantFirst =
     firstLine.cosinesDirector[2] * firstLine.cosinesDirector[2] * covarianceFirst[0] * covarianceFirst[1] +
     firstLine.cosinesDirector[1] * firstLine.cosinesDirector[1] * covarianceFirst[0] * covarianceFirst[2] +
     firstLine.cosinesDirector[0] * firstLine.cosinesDirector[0] * covarianceFirst[1] * covarianceFirst[2];
-  float determinantSecond =
+  double determinantSecond =
     secondLine.cosinesDirector[2] * secondLine.cosinesDirector[2] * covarianceSecond[0] * covarianceSecond[1] +
     secondLine.cosinesDirector[1] * secondLine.cosinesDirector[1] * covarianceSecond[0] * covarianceSecond[2] +
     secondLine.cosinesDirector[0] * secondLine.cosinesDirector[0] * covarianceSecond[1] * covarianceSecond[2];
@@ -111,9 +111,9 @@ GPUd() ClusterLinesGPU::ClusterLinesGPU(const Line& firstLine, const Line& secon
 GPUd() void ClusterLinesGPU::computeClusterCentroid()
 {
 
-  float determinant{mAMatrix[0] * (mAMatrix[3] * mAMatrix[5] - mAMatrix[4] * mAMatrix[4]) -
-                    mAMatrix[1] * (mAMatrix[1] * mAMatrix[5] - mAMatrix[4] * mAMatrix[2]) +
-                    mAMatrix[2] * (mAMatrix[1] * mAMatrix[4] - mAMatrix[2] * mAMatrix[3])};
+  double determinant{mAMatrix[0] * (mAMatrix[3] * mAMatrix[5] - mAMatrix[4] * mAMatrix[4]) -
+                     mAMatrix[1] * (mAMatrix[1] * mAMatrix[5] - mAMatrix[4] * mAMatrix[2]) +
+                     mAMatrix[2] * (mAMatrix[1] * mAMatrix[4] - mAMatrix[2] * mAMatrix[3])};
 
   if (determinant == 0) {
     return;

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/Context.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/Context.cu
@@ -23,7 +23,7 @@ namespace its
 namespace gpu
 {
 
-using utils::host::checkGPUError;
+using utils::checkGPUError;
 
 Context::Context(bool dumpDevices)
 {

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/Stream.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/Stream.cu
@@ -19,7 +19,7 @@ namespace its
 {
 namespace gpu
 {
-using utils::host::checkGPUError;
+using utils::checkGPUError;
 
 Stream::Stream()
 {

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/Stream.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/Stream.cu
@@ -12,6 +12,7 @@
 
 #include "ITStrackingGPU/Stream.h"
 #include "ITStrackingGPU/Utils.h"
+#include "GPUCommonLogger.h"
 
 namespace o2
 {
@@ -25,9 +26,9 @@ Stream::Stream()
 {
   checkGPUError(cudaStreamCreate(&mStream));
 }
-// usles
 Stream::~Stream()
 {
+  LOGP(info, "Destroying stream");
   checkGPUError(cudaStreamDestroy(mStream));
 }
 

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/Stream.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/Stream.cu
@@ -11,6 +11,7 @@
 ///
 
 #include "ITStrackingGPU/Stream.h"
+#include "ITStrackingGPU/Utils.h"
 
 namespace o2
 {
@@ -18,15 +19,16 @@ namespace its
 {
 namespace gpu
 {
+using utils::host::checkGPUError;
 
 Stream::Stream()
 {
-  discardResult(cudaStreamCreateWithFlags(&mStream, cudaStreamDefault));
+  checkGPUError(cudaStreamCreate(&mStream));
 }
 // usles
 Stream::~Stream()
 {
-  discardResult(cudaStreamDestroy(mStream));
+  checkGPUError(cudaStreamDestroy(mStream));
 }
 
 const GPUStream& Stream::get() const

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TimeFrameGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TimeFrameGPU.cu
@@ -15,6 +15,7 @@
 
 #include "ITStrackingGPU/Utils.h"
 #include "ITStrackingGPU/TimeFrameGPU.h"
+#include "ITStrackingGPU/TracerGPU.h"
 
 #include <unistd.h>
 
@@ -273,6 +274,7 @@ void TimeFrameGPU<nLayers>::initialise(const int iteration,
                                        const int maxLayers)
 {
   initDevice(mGpuConfig.nTimeFramePartitions);
+  RANGE("TimeFrame initialisation", 1);
   o2::its::TimeFrame::initialise(iteration, trkParam, maxLayers);
 }
 

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TimeFrameGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TimeFrameGPU.cu
@@ -29,7 +29,7 @@ using constants::MB;
 
 namespace gpu
 {
-using utils::host::checkGPUError;
+using utils::checkGPUError;
 
 template <int nLayers>
 struct StaticTrackingParameters {
@@ -261,6 +261,7 @@ template <int nLayers>
 TimeFrameGPU<nLayers>::TimeFrameGPU()
 {
   mIsGPU = true;
+  utils::getDeviceProp(0, true);
 }
 
 template <int nLayers>

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TimeFrameGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TimeFrameGPU.cu
@@ -28,192 +28,270 @@ using constants::MB;
 namespace gpu
 {
 using utils::host::checkGPUError;
-GPUh() void gpuThrowOnError()
-{
-  cudaError_t error = cudaGetLastError();
 
-  if (error != cudaSuccess) {
-    std::ostringstream errorString{};
-    errorString << GPU_ARCH << " API returned error  [" << cudaGetErrorString(error) << "] (code " << error << ")" << std::endl;
-    throw std::runtime_error{errorString.str()};
+template <int nLayers>
+struct StaticTrackingParameters {
+  StaticTrackingParameters<nLayers>& operator=(const StaticTrackingParameters<nLayers>& t) = default;
+  void set(const TrackingParameters& pars);
+
+  /// General parameters
+  int ClusterSharing = 0;
+  int MinTrackLength = nLayers;
+  float NSigmaCut = 5;
+  float PVres = 1.e-2f;
+  int DeltaROF = 0;
+  int ZBins{256};
+  int PhiBins{128};
+
+  /// Cell finding cuts
+  float CellDeltaTanLambdaSigma = 0.007f;
+};
+
+template <int nLayers>
+void StaticTrackingParameters<nLayers>::set(const TrackingParameters& pars)
+{
+  ClusterSharing = pars.ClusterSharing;
+  MinTrackLength = pars.MinTrackLength;
+  NSigmaCut = pars.NSigmaCut;
+  PVres = pars.PVres;
+  DeltaROF = pars.DeltaROF;
+  ZBins = pars.ZBins;
+  PhiBins = pars.PhiBins;
+  CellDeltaTanLambdaSigma = pars.CellDeltaTanLambdaSigma;
+}
+
+// GpuPartition
+template <int nLayers>
+GpuTimeFramePartition<nLayers>::~GpuTimeFramePartition()
+{
+  for (int i = 0; i < nLayers; ++i) {
+    checkGPUError(cudaFree(mROframesClustersDevice[i]));
+    checkGPUError(cudaFree(mClustersDevice[i]));
+    checkGPUError(cudaFree(mUsedClustersDevice[i]));
+    checkGPUError(cudaFree(mTrackingFrameInfoDevice[i]));
+    checkGPUError(cudaFree(mClusterExternalIndicesDevice[i]));
+    checkGPUError(cudaFree(mIndexTablesDevice[i]));
+    if (i < nLayers - 1) {
+      checkGPUError(cudaFree(mTrackletsDevice[i]));
+      checkGPUError(cudaFree(mTrackletsLookupTablesDevice[i]));
+      if (i < nLayers - 2) {
+        checkGPUError(cudaFree(mCellsDevice[i]));
+        checkGPUError(cudaFree(mCellsLookupTablesDevice[i]));
+      }
+    }
   }
 }
 
-template <int NLayers>
-TimeFrameGPU<NLayers>::TimeFrameGPU()
+template <int nLayers>
+void GpuTimeFramePartition<nLayers>::initDevice(const size_t nrof, const TimeFrameGPUConfig& config)
+{
+  for (int i = 0; i < nLayers; ++i) {
+    checkGPUError(cudaMalloc(reinterpret_cast<void**>(&(mROframesClustersDevice[i])), sizeof(int) * nrof));
+    checkGPUError(cudaMalloc(reinterpret_cast<void**>(&(mClustersDevice[i])), sizeof(Cluster) * config.clustersPerROfCapacity * nrof));
+    checkGPUError(cudaMalloc(reinterpret_cast<void**>(&(mUsedClustersDevice[i])), sizeof(unsigned char) * config.clustersPerROfCapacity * nrof));
+    checkGPUError(cudaMalloc(reinterpret_cast<void**>(&(mTrackingFrameInfoDevice[i])), sizeof(TrackingFrameInfo) * config.clustersPerROfCapacity * nrof));
+    checkGPUError(cudaMalloc(reinterpret_cast<void**>(&(mClusterExternalIndicesDevice[i])), sizeof(int) * config.clustersPerROfCapacity * nrof));
+    checkGPUError(cudaMalloc(reinterpret_cast<void**>(&(mIndexTablesDevice[i])), sizeof(int) * (256 * 128 + 1) * nrof));
+    if (i < nLayers - 1) {
+      checkGPUError(cudaMalloc(reinterpret_cast<void**>(&(mTrackletsDevice[i])), sizeof(Tracklet) * config.maxTrackletsPerCluster * config.clustersPerROfCapacity * nrof));
+      checkGPUError(cudaMalloc(reinterpret_cast<void**>(&(mTrackletsLookupTablesDevice[i])), sizeof(int) * config.clustersPerROfCapacity * nrof));
+      // checkGPUError(cudaMemset(mTrackletsLookupTablesDevice[i], 0, sizeof(int) * config.clustersPerROfCapacity * nrof));
+      if (i < nLayers - 2) {
+        checkGPUError(cudaMalloc(reinterpret_cast<void**>(&(mCellsDevice[i])), sizeof(Cell) * config.validatedTrackletsCapacity * nrof));
+        checkGPUError(cudaMalloc(reinterpret_cast<void**>(&(mCellsLookupTablesDevice[i])), sizeof(int) * config.validatedTrackletsCapacity * nrof));
+        // checkGPUError(cudaMemset(mCellsLookupTablesDevice[i], 0, sizeof(int) * config.validatedTrackletsCapacity * nrof));
+      }
+    }
+  }
+  checkGPUError(cudaMalloc(reinterpret_cast<void**>(&mCUBTmpBuffers), config.tmpCUBBufferSize * nrof));
+  checkGPUError(cudaMalloc(&mFoundTrackletsDevice, (nLayers - 1) * sizeof(int)));
+  checkGPUError(cudaMemset(mFoundTrackletsDevice, 0, (nLayers - 1) * sizeof(int)));
+  checkGPUError(cudaMalloc(&mFoundCellsDevice, (nLayers - 2) * sizeof(int)));
+  checkGPUError(cudaMemset(mFoundCellsDevice, 0, (nLayers - 2) * sizeof(int)));
+}
+
+// TimeFrameGPU
+template <int nLayers>
+TimeFrameGPU<nLayers>::TimeFrameGPU()
 {
   mIsGPU = true;
-  // getDeviceMemory(); To be updated
 }
 
-template <int NLayers>
-float TimeFrameGPU<NLayers>::getDeviceMemory()
+template <int nLayers>
+void TimeFrameGPU<nLayers>::initDevice()
 {
-  // We don't check if we can store the data in the GPU for the moment, only log it.
-  float totalMemory{0};
-  totalMemory += NLayers * mConfig.clustersPerLayerCapacity * sizeof(Cluster);
-  totalMemory += NLayers * mConfig.clustersPerLayerCapacity * sizeof(unsigned char);
-  totalMemory += NLayers * mConfig.clustersPerLayerCapacity * sizeof(TrackingFrameInfo);
-  totalMemory += NLayers * mConfig.clustersPerLayerCapacity * sizeof(int);
-  totalMemory += NLayers * mConfig.clustersPerROfCapacity * sizeof(int);
-  totalMemory += (NLayers - 1) * mConfig.trackletsCapacity * sizeof(Tracklet);
-  totalMemory += (NLayers - 1) * mConfig.nMaxROFs * (256 * 128 + 1) * sizeof(int);
-  totalMemory += 2 * mConfig.clustersPerLayerCapacity * sizeof(int);
-  totalMemory += 2 * mConfig.nMaxROFs * (ZBins * PhiBins + 1) * sizeof(int);
-  totalMemory += mConfig.trackletsCapacity * sizeof(Line);
-  totalMemory += mConfig.clustersPerLayerCapacity * sizeof(int);
-  totalMemory += mConfig.clustersPerLayerCapacity * sizeof(int);
-  totalMemory += mConfig.trackletsCapacity * sizeof(unsigned char);
-  totalMemory += mConfig.nMaxROFs * mConfig.tmpCUBBufferSize * sizeof(int);
-  totalMemory += 2 * mConfig.nMaxROFs * mConfig.maxCentroidsXYCapacity * sizeof(float);
-  totalMemory += mConfig.nMaxROFs * mConfig.maxLinesCapacity * sizeof(float);
-  for (size_t i{0}; i < 3; ++i) {
-    totalMemory += mConfig.nMaxROFs * mConfig.histConf.nBinsXYZ[i] * sizeof(float);
-  }
-  totalMemory += 3 * mConfig.nMaxROFs * sizeof(cub::KeyValuePair<int, int>);
-  totalMemory += 2 * mConfig.nMaxROFs * sizeof(float);
-  totalMemory += mConfig.nMaxROFs * mConfig.maxVerticesCapacity * sizeof(Vertex);
-
-  LOG(info) << fmt::format("Total requested memory for GPU: {:.2f} MB", totalMemory / MB);
-  LOG(info) << fmt::format("\t- Clusters: {:.2f} MB", NLayers * mConfig.clustersPerLayerCapacity * sizeof(Cluster) / MB);
-  LOG(info) << fmt::format("\t- Used clusters: {:.2f} MB", NLayers * mConfig.clustersPerLayerCapacity * sizeof(unsigned char) / MB);
-  LOG(info) << fmt::format("\t- Tracking frame info: {:.2f} MB", NLayers * mConfig.clustersPerLayerCapacity * sizeof(TrackingFrameInfo) / MB);
-  LOG(info) << fmt::format("\t- Cluster external indices: {:.2f} MB", NLayers * mConfig.clustersPerLayerCapacity * sizeof(int) / MB);
-  LOG(info) << fmt::format("\t- Clusters per ROf: {:.2f} MB", NLayers * mConfig.clustersPerROfCapacity * sizeof(int) / MB);
-  LOG(info) << fmt::format("\t- Tracklets: {:.2f} MB", (NLayers - 1) * mConfig.trackletsCapacity * sizeof(Tracklet) / MB);
-  LOG(info) << fmt::format("\t- Tracklet index tables: {:.2f} MB", (NLayers - 1) * mConfig.nMaxROFs * (256 * 128 + 1) * sizeof(int) / MB);
-  LOG(info) << fmt::format("\t- N tracklets per cluster: {:.2f} MB", 2 * mConfig.clustersPerLayerCapacity * sizeof(int) / MB);
-  LOG(info) << fmt::format("\t- Index tables: {:.2f} MB", 2 * mConfig.nMaxROFs * (ZBins * PhiBins + 1) * sizeof(int) / MB);
-  LOG(info) << fmt::format("\t- Lines: {:.2f} MB", mConfig.trackletsCapacity * sizeof(Line) / MB);
-  LOG(info) << fmt::format("\t- N found lines: {:.2f} MB", mConfig.clustersPerLayerCapacity * sizeof(int) / MB);
-  LOG(info) << fmt::format("\t- N exclusive-scan found lines: {:.2f} MB", mConfig.clustersPerLayerCapacity * sizeof(int) / MB);
-  LOG(info) << fmt::format("\t- Used tracklets: {:.2f} MB", mConfig.trackletsCapacity * sizeof(unsigned char) / MB);
-  LOG(info) << fmt::format("\t- CUB tmp buffers: {:.2f} MB", mConfig.nMaxROFs * mConfig.tmpCUBBufferSize / MB);
-  LOG(info) << fmt::format("\t- XY centroids: {:.2f} MB", 2 * mConfig.nMaxROFs * mConfig.maxCentroidsXYCapacity * sizeof(float) / MB);
-  LOG(info) << fmt::format("\t- Z centroids: {:.2f} MB", mConfig.nMaxROFs * mConfig.maxLinesCapacity * sizeof(float) / MB);
-  LOG(info) << fmt::format("\t- XY histograms: {:.2f} MB", 2 * mConfig.nMaxROFs * mConfig.histConf.nBinsXYZ[0] * sizeof(int) / MB);
-  LOG(info) << fmt::format("\t- Z histograms: {:.2f} MB", mConfig.nMaxROFs * mConfig.histConf.nBinsXYZ[2] * sizeof(int) / MB);
-  LOG(info) << fmt::format("\t- TMP Vertex position bins: {:.2f} MB", 3 * mConfig.nMaxROFs * sizeof(cub::KeyValuePair<int, int>) / MB);
-  LOG(info) << fmt::format("\t- Beam positions: {:.2f} MB", 2 * mConfig.nMaxROFs * sizeof(float) / MB);
-  LOG(info) << fmt::format("\t- Vertices: {:.2f} MB", mConfig.nMaxROFs * mConfig.maxVerticesCapacity * sizeof(Vertex) / MB);
-
-  return totalMemory;
+  StaticTrackingParameters<nLayers> pars;
+  checkGPUError(cudaMalloc(reinterpret_cast<void**>(&mTrackingParamsDevice), sizeof(gpu::StaticTrackingParameters<nLayers>)));
+  checkGPUError(cudaMemcpy(mTrackingParamsDevice, &pars, sizeof(gpu::StaticTrackingParameters<nLayers>), cudaMemcpyHostToDevice));
 }
+// template <int nLayers>
+// float TimeFrameGPU<nLayers>::getDeviceMemory()
+// {
+//   // We don't check if we can store the data in the GPU for the moment, only log it.
+//   float totalMemory{0};
+//   totalMemory += nLayers * mConfig.clustersPerLayerCapacity * sizeof(Cluster);
+//   totalMemory += nLayers * mConfig.clustersPerLayerCapacity * sizeof(unsigned char);
+//   totalMemory += nLayers * mConfig.clustersPerLayerCapacity * sizeof(TrackingFrameInfo);
+//   totalMemory += nLayers * mConfig.clustersPerLayerCapacity * sizeof(int);
+//   totalMemory += nLayers * mConfig.clustersPerROfCapacity * sizeof(int);
+//   totalMemory += (nLayers - 1) * mConfig.trackletsCapacity * sizeof(Tracklet);
+//   totalMemory += (nLayers - 1) * mConfig.nMaxROFs * (256 * 128 + 1) * sizeof(int);
+//   totalMemory += 2 * mConfig.clustersPerLayerCapacity * sizeof(int);
+//   totalMemory += 2 * mConfig.nMaxROFs * (ZBins * PhiBins + 1) * sizeof(int);
+//   totalMemory += mConfig.trackletsCapacity * sizeof(Line);
+//   totalMemory += mConfig.clustersPerLayerCapacity * sizeof(int);
+//   totalMemory += mConfig.clustersPerLayerCapacity * sizeof(int);
+//   totalMemory += mConfig.trackletsCapacity * sizeof(unsigned char);
+//   totalMemory += mConfig.nMaxROFs * mConfig.tmpCUBBufferSize * sizeof(int);
+//   totalMemory += 2 * mConfig.nMaxROFs * mConfig.maxCentroidsXYCapacity * sizeof(float);
+//   totalMemory += mConfig.nMaxROFs * mConfig.maxLinesCapacity * sizeof(float);
+//   for (size_t i{0}; i < 3; ++i) {
+//     totalMemory += mConfig.nMaxROFs * mConfig.histConf.nBinsXYZ[i] * sizeof(float);
+//   }
+//   totalMemory += 3 * mConfig.nMaxROFs * sizeof(cub::KeyValuePair<int, int>);
+//   totalMemory += 2 * mConfig.nMaxROFs * sizeof(float);
+//   totalMemory += mConfig.nMaxROFs * mConfig.maxVerticesCapacity * sizeof(Vertex);
 
-template <int NLayers>
-template <unsigned char isTracker>
-void TimeFrameGPU<NLayers>::initialiseDevice(const TrackingParameters& trkParam)
-{
-  mTrackletSizeHost.resize(NLayers - 1, 0);
-  mCellSizeHost.resize(NLayers - 2, 0);
-  for (int iLayer{0}; iLayer < NLayers - 1; ++iLayer) { // Tracker and vertexer
-    mTrackletsD[iLayer] = Vector<Tracklet>{mConfig.trackletsCapacity, mConfig.trackletsCapacity};
-    auto thrustTrackletsBegin = thrust::device_ptr<Tracklet>(mTrackletsD[iLayer].get());
-    auto thrustTrackletsEnd = thrustTrackletsBegin + mConfig.trackletsCapacity;
-    thrust::fill(thrustTrackletsBegin, thrustTrackletsEnd, Tracklet{});
-    mTrackletsLookupTablesD[iLayer].resetWithInt(mClusters[iLayer].size());
-    if (iLayer < NLayers - 2) {
-      mCellsD[iLayer] = Vector<Cell>{mConfig.validatedTrackletsCapacity, mConfig.validatedTrackletsCapacity};
-      mCellsLookupTablesD[iLayer] = Vector<int>{mConfig.cellsLUTsize, mConfig.cellsLUTsize};
-      mCellsLookupTablesD[iLayer].resetWithInt(mConfig.cellsLUTsize);
-    }
-  }
+//   LOG(info) << fmt::format("Total requested memory for GPU: {:.2f} MB", totalMemory / MB);
+//   LOG(info) << fmt::format("\t- Clusters: {:.2f} MB", nLayers * mConfig.clustersPerLayerCapacity * sizeof(Cluster) / MB);
+//   LOG(info) << fmt::format("\t- Used clusters: {:.2f} MB", nLayers * mConfig.clustersPerLayerCapacity * sizeof(unsigned char) / MB);
+//   LOG(info) << fmt::format("\t- Tracking frame info: {:.2f} MB", nLayers * mConfig.clustersPerLayerCapacity * sizeof(TrackingFrameInfo) / MB);
+//   LOG(info) << fmt::format("\t- Cluster external indices: {:.2f} MB", nLayers * mConfig.clustersPerLayerCapacity * sizeof(int) / MB);
+//   LOG(info) << fmt::format("\t- Clusters per ROf: {:.2f} MB", nLayers * mConfig.clustersPerROfCapacity * sizeof(int) / MB);
+//   LOG(info) << fmt::format("\t- Tracklets: {:.2f} MB", (nLayers - 1) * mConfig.trackletsCapacity * sizeof(Tracklet) / MB);
+//   LOG(info) << fmt::format("\t- Tracklet index tables: {:.2f} MB", (nLayers - 1) * mConfig.nMaxROFs * (256 * 128 + 1) * sizeof(int) / MB);
+//   LOG(info) << fmt::format("\t- N tracklets per cluster: {:.2f} MB", 2 * mConfig.clustersPerLayerCapacity * sizeof(int) / MB);
+//   LOG(info) << fmt::format("\t- Index tables: {:.2f} MB", 2 * mConfig.nMaxROFs * (ZBins * PhiBins + 1) * sizeof(int) / MB);
+//   LOG(info) << fmt::format("\t- Lines: {:.2f} MB", mConfig.trackletsCapacity * sizeof(Line) / MB);
+//   LOG(info) << fmt::format("\t- N found lines: {:.2f} MB", mConfig.clustersPerLayerCapacity * sizeof(int) / MB);
+//   LOG(info) << fmt::format("\t- N exclusive-scan found lines: {:.2f} MB", mConfig.clustersPerLayerCapacity * sizeof(int) / MB);
+//   LOG(info) << fmt::format("\t- Used tracklets: {:.2f} MB", mConfig.trackletsCapacity * sizeof(unsigned char) / MB);
+//   LOG(info) << fmt::format("\t- CUB tmp buffers: {:.2f} MB", mConfig.nMaxROFs * mConfig.tmpCUBBufferSize / MB);
+//   LOG(info) << fmt::format("\t- XY centroids: {:.2f} MB", 2 * mConfig.nMaxROFs * mConfig.maxCentroidsXYCapacity * sizeof(float) / MB);
+//   LOG(info) << fmt::format("\t- Z centroids: {:.2f} MB", mConfig.nMaxROFs * mConfig.maxLinesCapacity * sizeof(float) / MB);
+//   LOG(info) << fmt::format("\t- XY histograms: {:.2f} MB", 2 * mConfig.nMaxROFs * mConfig.histConf.nBinsXYZ[0] * sizeof(int) / MB);
+//   LOG(info) << fmt::format("\t- Z histograms: {:.2f} MB", mConfig.nMaxROFs * mConfig.histConf.nBinsXYZ[2] * sizeof(int) / MB);
+//   LOG(info) << fmt::format("\t- TMP Vertex position bins: {:.2f} MB", 3 * mConfig.nMaxROFs * sizeof(cub::KeyValuePair<int, int>) / MB);
+//   LOG(info) << fmt::format("\t- Beam positions: {:.2f} MB", 2 * mConfig.nMaxROFs * sizeof(float) / MB);
+//   LOG(info) << fmt::format("\t- Vertices: {:.2f} MB", mConfig.nMaxROFs * mConfig.maxVerticesCapacity * sizeof(Vertex) / MB);
 
-  for (auto iComb{0}; iComb < 2; ++iComb) { // Vertexer only
-    mNTrackletsPerClusterD[iComb] = Vector<int>{mConfig.clustersPerLayerCapacity, mConfig.clustersPerLayerCapacity};
-  }
-  mLines = Vector<Line>{mConfig.trackletsCapacity, mConfig.trackletsCapacity};
-  mNFoundLines = Vector<int>{mConfig.clustersPerLayerCapacity, mConfig.clustersPerLayerCapacity};
-  mNFoundLines.resetWithInt(mConfig.clustersPerLayerCapacity);
-  mNExclusiveFoundLines = Vector<int>{mConfig.clustersPerLayerCapacity, mConfig.clustersPerLayerCapacity};
-  mNExclusiveFoundLines.resetWithInt(mConfig.clustersPerLayerCapacity);
-  mUsedTracklets = Vector<unsigned char>{mConfig.trackletsCapacity, mConfig.trackletsCapacity};
-  discardResult(cudaMalloc(&mCUBTmpBuffers, mConfig.nMaxROFs * mConfig.tmpCUBBufferSize));
-  discardResult(cudaMalloc(&mDeviceFoundTracklets, (NLayers - 1) * sizeof(int)));
-  discardResult(cudaMemset(mDeviceFoundTracklets, 0, (NLayers - 1) * sizeof(int)));
-  discardResult(cudaMalloc(&mDeviceFoundCells, (NLayers - 2) * sizeof(int)));
-  discardResult(cudaMemset(mDeviceFoundCells, 0, (NLayers - 2) * sizeof(int)));
-  mXYCentroids = Vector<float>{2 * mConfig.nMaxROFs * mConfig.maxCentroidsXYCapacity, 2 * mConfig.nMaxROFs * mConfig.maxCentroidsXYCapacity};
-  mZCentroids = Vector<float>{mConfig.nMaxROFs * mConfig.maxLinesCapacity, mConfig.nMaxROFs * mConfig.maxLinesCapacity};
-  for (size_t i{0}; i < 3; ++i) {
-    mXYZHistograms[i] = Vector<int>{mConfig.nMaxROFs * mConfig.histConf.nBinsXYZ[i], mConfig.nMaxROFs * mConfig.histConf.nBinsXYZ[i]};
-  }
-  mTmpVertexPositionBins = Vector<cub::KeyValuePair<int, int>>{3 * mConfig.nMaxROFs, 3 * mConfig.nMaxROFs};
-  mBeamPosition = Vector<float>{2 * mConfig.nMaxROFs, 2 * mConfig.nMaxROFs};
-  mGPUVertices = Vector<Vertex>{mConfig.nMaxROFs * mConfig.maxVerticesCapacity, mConfig.nMaxROFs * mConfig.maxVerticesCapacity};
-  //////////////////////////////////////////////////////////////////////////////
-  constexpr int layers = isTracker ? NLayers : 3;
-  for (int iLayer{0}; iLayer < layers; ++iLayer) {
-    mClustersD[iLayer].reset(mClusters[iLayer].data(), static_cast<int>(mClusters[iLayer].size()));
-  }
-  if constexpr (isTracker) {
-    StaticTrackingParameters<NLayers> pars;
-    pars.set(trkParam);
-    checkGPUError(cudaMalloc(reinterpret_cast<void**>(&mDeviceTrackingParams), sizeof(gpu::StaticTrackingParameters<NLayers>)), __FILE__, __LINE__);
-    checkGPUError(cudaMalloc(reinterpret_cast<void**>(&mDeviceIndexTableUtils), sizeof(IndexTableUtils)), __FILE__, __LINE__);
-    checkGPUError(cudaMemcpy(mDeviceTrackingParams, &pars, sizeof(gpu::StaticTrackingParameters<NLayers>), cudaMemcpyHostToDevice), __FILE__, __LINE__);
-    checkGPUError(cudaMemcpy(mDeviceIndexTableUtils, &mIndexTableUtils, sizeof(IndexTableUtils), cudaMemcpyHostToDevice), __FILE__, __LINE__);
-    // Tracker-only: we don't need to copy data in vertexer
-    for (int iLayer{0}; iLayer < NLayers; ++iLayer) {
-      mUsedClustersD[iLayer].reset(mUsedClusters[iLayer].data(), static_cast<int>(mUsedClusters[iLayer].size()));
-      mTrackingFrameInfoD[iLayer].reset(mTrackingFrameInfo[iLayer].data(), static_cast<int>(mTrackingFrameInfo[iLayer].size()));
-      mClusterExternalIndicesD[iLayer].reset(mClusterExternalIndices[iLayer].data(), static_cast<int>(mClusterExternalIndices[iLayer].size()));
-      mROframesClustersD[iLayer].reset(mROframesClusters[iLayer].data(), static_cast<int>(mROframesClusters[iLayer].size()));
-      mIndexTablesD[iLayer].reset(mIndexTables[iLayer].data(), static_cast<int>(mIndexTables[iLayer].size()));
-    }
-  } else {
-    mIndexTablesD[0].reset(getIndexTableWhole(0).data(), static_cast<int>(getIndexTableWhole(0).size()));
-    mIndexTablesD[2].reset(getIndexTableWhole(2).data(), static_cast<int>(getIndexTableWhole(2).size()));
-  }
+//   return totalMemory;
+// }
 
-  gpuThrowOnError();
-}
+// template <int nLayers>
+// template <unsigned char isTracker>
+// void TimeFrameGPU<nLayers>::initialiseDevice(const TrackingParameters& trkParam)
+// {
+//   mTrackletSizeHost.resize(nLayers - 1, 0);
+//   mCellSizeHost.resize(nLayers - 2, 0);
+//   for (int iLayer{0}; iLayer < nLayers - 1; ++iLayer) { // Tracker and vertexer
+//     mTrackletsD[iLayer] = Vector<Tracklet>{mConfig.trackletsCapacity, mConfig.trackletsCapacity};
+//     auto thrustTrackletsBegin = thrust::device_ptr<Tracklet>(mTrackletsD[iLayer].get());
+//     auto thrustTrackletsEnd = thrustTrackletsBegin + mConfig.trackletsCapacity;
+//     thrust::fill(thrustTrackletsBegin, thrustTrackletsEnd, Tracklet{});
+//     mTrackletsLookupTablesD[iLayer].resetWithInt(mClusters[iLayer].size());
+//     if (iLayer < nLayers - 2) {
+//       mCellsD[iLayer] = Vector<Cell>{mConfig.validatedTrackletsCapacity, mConfig.validatedTrackletsCapacity};
+//       mCellsLookupTablesD[iLayer] = Vector<int>{mConfig.cellsLUTsize, mConfig.cellsLUTsize};
+//       mCellsLookupTablesD[iLayer].resetWithInt(mConfig.cellsLUTsize);
+//     }
+//   }
 
-template <int NLayers>
-void TimeFrameGPU<NLayers>::initialise(const int iteration,
-                                       const TrackingParameters& trkParam,
-                                       const int maxLayers)
-{
-  o2::its::TimeFrame::initialise(iteration, trkParam, maxLayers);
-  checkBufferSizes();
-  if (maxLayers < NLayers) {
-    initialiseDevice<false>(trkParam); // vertexer
-  } else {
-    initialiseDevice<true>(trkParam); // tracker
-  }
-}
+//   for (auto iComb{0}; iComb < 2; ++iComb) { // Vertexer only
+//     mNTrackletsPerClusterD[iComb] = Vector<int>{mConfig.clustersPerLayerCapacity, mConfig.clustersPerLayerCapacity};
+//   }
+//   mLines = Vector<Line>{mConfig.trackletsCapacity, mConfig.trackletsCapacity};
+//   mNFoundLines = Vector<int>{mConfig.clustersPerLayerCapacity, mConfig.clustersPerLayerCapacity};
+//   mNFoundLines.resetWithInt(mConfig.clustersPerLayerCapacity);
+//   mNExclusiveFoundLines = Vector<int>{mConfig.clustersPerLayerCapacity, mConfig.clustersPerLayerCapacity};
+//   mNExclusiveFoundLines.resetWithInt(mConfig.clustersPerLayerCapacity);
+//   mUsedTracklets = Vector<unsigned char>{mConfig.trackletsCapacity, mConfig.trackletsCapacity};
+//   discardResult(cudaMalloc(&mCUBTmpBuffers, mConfig.nMaxROFs * mConfig.tmpCUBBufferSize));
+//   discardResult(cudaMalloc(&mDeviceFoundTracklets, (nLayers - 1) * sizeof(int)));
+//   discardResult(cudaMemset(mDeviceFoundTracklets, 0, (nLayers - 1) * sizeof(int)));
+//   discardResult(cudaMalloc(&mDeviceFoundCells, (nLayers - 2) * sizeof(int)));
+//   discardResult(cudaMemset(mDeviceFoundCells, 0, (nLayers - 2) * sizeof(int)));
+//   mXYCentroids = Vector<float>{2 * mConfig.nMaxROFs * mConfig.maxCentroidsXYCapacity, 2 * mConfig.nMaxROFs * mConfig.maxCentroidsXYCapacity};
+//   mZCentroids = Vector<float>{mConfig.nMaxROFs * mConfig.maxLinesCapacity, mConfig.nMaxROFs * mConfig.maxLinesCapacity};
+//   for (size_t i{0}; i < 3; ++i) {
+//     mXYZHistograms[i] = Vector<int>{mConfig.nMaxROFs * mConfig.histConf.nBinsXYZ[i], mConfig.nMaxROFs * mConfig.histConf.nBinsXYZ[i]};
+//   }
+//   mTmpVertexPositionBins = Vector<cub::KeyValuePair<int, int>>{3 * mConfig.nMaxROFs, 3 * mConfig.nMaxROFs};
+//   mBeamPosition = Vector<float>{2 * mConfig.nMaxROFs, 2 * mConfig.nMaxROFs};
+//   mGPUVertices = Vector<Vertex>{mConfig.nMaxROFs * mConfig.maxVerticesCapacity, mConfig.nMaxROFs * mConfig.maxVerticesCapacity};
+//   //////////////////////////////////////////////////////////////////////////////
+//   constexpr int layers = isTracker ? nLayers : 3;
+//   for (int iLayer{0}; iLayer < layers; ++iLayer) {
+//     mClustersD[iLayer].reset(mClusters[iLayer].data(), static_cast<int>(mClusters[iLayer].size()));
+//   }
+//   if constexpr (isTracker) {
+//     StaticTrackingParameters<nLayers> pars;
+//     pars.set(trkParam);
+//     checkGPUError(cudaMalloc(reinterpret_cast<void**>(&mDeviceTrackingParams), sizeof(gpu::StaticTrackingParameters<nLayers>)), __FILE__, __LINE__);
+//     checkGPUError(cudaMalloc(reinterpret_cast<void**>(&mDeviceIndexTableUtils), sizeof(IndexTableUtils)), __FILE__, __LINE__);
+//     checkGPUError(cudaMemcpy(mDeviceTrackingParams, &pars, sizeof(gpu::StaticTrackingParameters<nLayers>), cudaMemcpyHostToDevice), __FILE__, __LINE__);
+//     checkGPUError(cudaMemcpy(mDeviceIndexTableUtils, &mIndexTableUtils, sizeof(IndexTableUtils), cudaMemcpyHostToDevice), __FILE__, __LINE__);
+//     // Tracker-only: we don't need to copy data in vertexer
+//     for (int iLayer{0}; iLayer < nLayers; ++iLayer) {
+//       mUsedClustersD[iLayer].reset(mUsedClusters[iLayer].data(), static_cast<int>(mUsedClusters[iLayer].size()));
+//       mTrackingFrameInfoD[iLayer].reset(mTrackingFrameInfo[iLayer].data(), static_cast<int>(mTrackingFrameInfo[iLayer].size()));
+//       mClusterExternalIndicesD[iLayer].reset(mClusterExternalIndices[iLayer].data(), static_cast<int>(mClusterExternalIndices[iLayer].size()));
+//       mROframesClustersD[iLayer].reset(mROframesClusters[iLayer].data(), static_cast<int>(mROframesClusters[iLayer].size()));
+//       mIndexTablesD[iLayer].reset(mIndexTables[iLayer].data(), static_cast<int>(mIndexTables[iLayer].size()));
+//     }
+//   } else {
+//     mIndexTablesD[0].reset(getIndexTableWhole(0).data(), static_cast<int>(getIndexTableWhole(0).size()));
+//     mIndexTablesD[2].reset(getIndexTableWhole(2).data(), static_cast<int>(getIndexTableWhole(2).size()));
+//   }
 
-template <int NLayers>
-TimeFrameGPU<NLayers>::~TimeFrameGPU()
-{
-  discardResult(cudaFree(mCUBTmpBuffers));
-  discardResult(cudaFree(mDeviceFoundTracklets));
-  discardResult(cudaFree(mDeviceTrackingParams));
-  discardResult(cudaFree(mDeviceIndexTableUtils));
-  discardResult(cudaFree(mDeviceFoundCells));
-}
+//   gpuThrowOnError();
+// }
 
-template <int NLayers>
-void TimeFrameGPU<NLayers>::checkBufferSizes()
-{
-  for (int iLayer{0}; iLayer < NLayers; ++iLayer) {
-    if (mClusters[iLayer].size() > mConfig.clustersPerLayerCapacity) {
-      LOGP(error, "Number of clusters on layer {} is {} and exceeds the GPU configuration defined one: {}", iLayer, mClusters[iLayer].size(), mConfig.clustersPerLayerCapacity);
-    }
-    if (mTrackingFrameInfo[iLayer].size() > mConfig.clustersPerLayerCapacity) {
-      LOGP(error, "Number of tracking frame info on layer {} is {} and exceeds the GPU configuration defined one: {}", iLayer, mTrackingFrameInfo[iLayer].size(), mConfig.clustersPerLayerCapacity);
-    }
-    if (mClusterExternalIndices[iLayer].size() > mConfig.clustersPerLayerCapacity) {
-      LOGP(error, "Number of external indices on layer {} is {} and exceeds the GPU configuration defined one: {}", iLayer, mClusterExternalIndices[iLayer].size(), mConfig.clustersPerLayerCapacity);
-    }
-    if (mROframesClusters[iLayer].size() > mConfig.clustersPerROfCapacity) {
-      LOGP(error, "Size of clusters per roframe on layer {} is {} and exceeds the GPU configuration defined one: {}", iLayer, mROframesClusters[iLayer].size(), mConfig.clustersPerROfCapacity);
-    }
-  }
-  if (mNrof > mConfig.nMaxROFs) {
-    LOGP(error, "Number of ROFs in timeframe is {} and exceeds the GPU configuration defined one: {}", mNrof, mConfig.nMaxROFs);
-  }
-}
+// template <int nLayers>
+// void TimeFrameGPU<nLayers>::initialise(const int iteration,
+//                                        const TrackingParameters& trkParam,
+//                                        const int maxLayers)
+// {
+//   o2::its::TimeFrame::initialise(iteration, trkParam, maxLayers);
+//   checkBufferSizes();
+//   if (maxLayers < nLayers) {
+//     initialiseDevice<false>(trkParam); // vertexer
+//   } else {
+//     initialiseDevice<true>(trkParam); // tracker
+//   }
+// }
+
+// template <int nLayers>
+// TimeFrameGPU<nLayers>::~TimeFrameGPU()
+// {
+//   discardResult(cudaFree(mCUBTmpBuffers));
+//   discardResult(cudaFree(mDeviceFoundTracklets));
+//   discardResult(cudaFree(mDeviceTrackingParams));
+//   discardResult(cudaFree(mDeviceIndexTableUtils));
+//   discardResult(cudaFree(mDeviceFoundCells));
+// }
+
+// template <int nLayers>
+// void TimeFrameGPU<nLayers>::checkBufferSizes()
+// {
+//   for (int iLayer{0}; iLayer < nLayers; ++iLayer) {
+//     if (mClusters[iLayer].size() > mConfig.clustersPerLayerCapacity) {
+//       LOGP(error, "Number of clusters on layer {} is {} and exceeds the GPU configuration defined one: {}", iLayer, mClusters[iLayer].size(), mConfig.clustersPerLayerCapacity);
+//     }
+//     if (mTrackingFrameInfo[iLayer].size() > mConfig.clustersPerLayerCapacity) {
+//       LOGP(error, "Number of tracking frame info on layer {} is {} and exceeds the GPU configuration defined one: {}", iLayer, mTrackingFrameInfo[iLayer].size(), mConfig.clustersPerLayerCapacity);
+//     }
+//     if (mClusterExternalIndices[iLayer].size() > mConfig.clustersPerLayerCapacity) {
+//       LOGP(error, "Number of external indices on layer {} is {} and exceeds the GPU configuration defined one: {}", iLayer, mClusterExternalIndices[iLayer].size(), mConfig.clustersPerLayerCapacity);
+//     }
+//     if (mROframesClusters[iLayer].size() > mConfig.clustersPerROfCapacity) {
+//       LOGP(error, "Size of clusters per roframe on layer {} is {} and exceeds the GPU configuration defined one: {}", iLayer, mROframesClusters[iLayer].size(), mConfig.clustersPerROfCapacity);
+//     }
+//   }
+//   if (mNrof > mConfig.nMaxROFs) {
+//     LOGP(error, "Number of ROFs in timeframe is {} and exceeds the GPU configuration defined one: {}", mNrof, mConfig.nMaxROFs);
+//   }
+// }
 
 template class TimeFrameGPU<7>;
 } // namespace gpu

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TimeFrameGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TimeFrameGPU.cu
@@ -271,6 +271,12 @@ size_t GpuTimeFrameChunk<nLayers>::copyDeviceData(const size_t startRof, const i
                                   mHostClusters[i].data(),
                                   (int)std::min(mHostClusters[i].size(), mTFGconf->clustersPerROfCapacity * mNRof) * sizeof(Cluster),
                                   cudaMemcpyHostToDevice, stream.get()));
+    if (mHostIndexTables[i].data()) {
+      checkGPUError(cudaMemcpyAsync(mIndexTablesDevice[i],
+                                    mHostIndexTables[i].data(),
+                                    mHostIndexTables[i].size() * sizeof(int),
+                                    cudaMemcpyHostToDevice, stream.get()));
+    }
   }
   return mHostNClustersROF[0].size(); // We want to return for how much ROFs we loaded the data.
 }

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TimeFrameGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TimeFrameGPU.cu
@@ -91,7 +91,7 @@ void GpuTimeFrameChunk<nLayers>::allocate(const size_t nrof, Stream& stream)
   checkGPUError(cudaMallocAsync(reinterpret_cast<void**>(&mCUBTmpBufferDevice), mTFGconf->tmpCUBBufferSize * nrof, stream.get()));
   checkGPUError(cudaMallocAsync(reinterpret_cast<void**>(&mLinesDevice), sizeof(Line) * mTFGconf->maxTrackletsPerCluster * mTFGconf->clustersPerROfCapacity * nrof, stream.get()));
   checkGPUError(cudaMallocAsync(reinterpret_cast<void**>(&mNFoundLinesDevice), sizeof(int) * mTFGconf->clustersPerROfCapacity * nrof, stream.get()));
-  checkGPUError(cudaMallocAsync(reinterpret_cast<void**>(&mNExclusiveFoundLinesDevice), sizeof(int) * mTFGconf->clustersPerROfCapacity * nrof, stream.get()));
+  checkGPUError(cudaMallocAsync(reinterpret_cast<void**>(&mNExclusiveFoundLinesDevice), sizeof(int) * mTFGconf->clustersPerROfCapacity * nrof + 1, stream.get())); // + 1 for cub::DeviceScan::ExclusiveSum, to cover cases where we have maximum number of clusters per ROF
   checkGPUError(cudaMallocAsync(reinterpret_cast<void**>(&mUsedTrackletsDevice), sizeof(unsigned char) * mTFGconf->maxTrackletsPerCluster * mTFGconf->clustersPerROfCapacity * nrof, stream.get()));
   checkGPUError(cudaMallocAsync(reinterpret_cast<void**>(&mClusteredLinesDevice), sizeof(int) * mTFGconf->clustersPerROfCapacity * mTFGconf->maxTrackletsPerCluster * nrof, stream.get()));
 

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TimeFrameGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TimeFrameGPU.cu
@@ -333,8 +333,8 @@ void TimeFrameGPU<nLayers>::initDevice(const int chunks, const IndexTableUtils* 
   checkGPUError(cudaMemcpy(mTrackingParamsDevice, &mStaticTrackingParams, sizeof(gpu::StaticTrackingParameters<nLayers>), cudaMemcpyHostToDevice));
   if (utils) { // In a sense this check is a proxy to know whether this is the vertexergpu calling.
     for (auto iLayer{0}; iLayer < maxLayers; ++iLayer) {
-      checkGPUError(cudaMalloc(reinterpret_cast<void**>(&mROframesClustersDevice[iLayer]), mNrof * sizeof(int)));
-      checkGPUError(cudaMemcpy(mROframesClustersDevice[iLayer], mROframesClusters[iLayer].data(), mNrof * sizeof(int), cudaMemcpyHostToDevice));
+      checkGPUError(cudaMalloc(reinterpret_cast<void**>(&mROframesClustersDevice[iLayer]),  mROframesClusters[iLayer].size() * sizeof(int)));
+      checkGPUError(cudaMemcpy(mROframesClustersDevice[iLayer], mROframesClusters[iLayer].data(),  mROframesClusters[iLayer].size() * sizeof(int), cudaMemcpyHostToDevice));
     }
     checkGPUError(cudaMalloc(reinterpret_cast<void**>(&mIndexTableUtilsDevice), sizeof(IndexTableUtils)));
     checkGPUError(cudaMemcpy(mIndexTableUtilsDevice, utils, sizeof(IndexTableUtils), cudaMemcpyHostToDevice));

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TracerGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TracerGPU.cu
@@ -1,0 +1,47 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "ITStrackingGPU/TracerGPU.h"
+
+#if !defined(__HIPCC__) && defined(__USE_GPU_TRACER__)
+#include "nvToolsExt.h"
+
+constexpr uint32_t colors[] = {0xff00ff00, 0xff0000ff, 0xffffff00, 0xffff00ff, 0xff00ffff, 0xffff0000, 0xffffffff};
+constexpr int num_colors = sizeof(colors) / sizeof(uint32_t);
+
+namespace o2
+{
+namespace its
+{
+namespace gpu
+{
+Tracer::Tracer(const char* name, int color_id)
+{
+  color_id = color_id % num_colors;
+  nvtxEventAttributes_t eventAttrib = {0};
+  eventAttrib.version = NVTX_VERSION;
+  eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+  eventAttrib.colorType = NVTX_COLOR_ARGB;
+  eventAttrib.color = colors[color_id];
+  eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+  eventAttrib.message.ascii = name;
+  nvtxRangePushEx(&eventAttrib);
+}
+
+Tracer::~Tracer()
+{
+  nvtxRangePop();
+}
+
+} // namespace gpu
+} // namespace its
+} // namespace o2
+#endif

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TrackerTraitsGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TrackerTraitsGPU.cu
@@ -258,202 +258,202 @@ void TrackerTraitsGPU<NLayers>::initialiseTimeFrame(const int iteration)
 template <int NLayers>
 void TrackerTraitsGPU<NLayers>::computeLayerTracklets(const int iteration)
 {
-  const Vertex diamondVert({mTrkParams[iteration].Diamond[0], mTrkParams[iteration].Diamond[1], mTrkParams[iteration].Diamond[2]}, {25.e-6f, 0.f, 0.f, 25.e-6f, 0.f, 36.f}, 1, 1.f);
-  gsl::span<const Vertex> diamondSpan(&diamondVert, 1);
-  size_t bufferSize = mTimeFrameGPU->getConfig().tmpCUBBufferSize;
+  // const Vertex diamondVert({mTrkParams[iteration].Diamond[0], mTrkParams[iteration].Diamond[1], mTrkParams[iteration].Diamond[2]}, {25.e-6f, 0.f, 0.f, 25.e-6f, 0.f, 36.f}, 1, 1.f);
+  // gsl::span<const Vertex> diamondSpan(&diamondVert, 1);
+  // size_t bufferSize = mTimeFrameGPU->getConfig().tmpCUBBufferSize;
 
-  for (int rof0{0}; rof0 < mTimeFrameGPU->getNrof(); ++rof0) {
-    gsl::span<const Vertex> primaryVertices = mTrkParams[iteration].UseDiamond ? diamondSpan : mTimeFrameGPU->getPrimaryVertices(rof0); // replace with GPU one
-    std::vector<Vertex> paddedVertices;
-    for (int iVertex{0}; iVertex < mTimeFrameGPU->getConfig().maxVerticesCapacity; ++iVertex) {
-      if (iVertex < primaryVertices.size()) {
-        paddedVertices.emplace_back(primaryVertices[iVertex]);
-      } else {
-        paddedVertices.emplace_back(Vertex());
-      }
-    }
-    checkGPUError(cudaMemcpy(mTimeFrameGPU->getDeviceVertices(rof0), paddedVertices.data(), mTimeFrameGPU->getConfig().maxVerticesCapacity * sizeof(Vertex), cudaMemcpyHostToDevice), __FILE__, __LINE__);
-    for (int iLayer{0}; iLayer < NLayers - 1; ++iLayer) {
-      const dim3 threadsPerBlock{gpu::utils::host::getBlockSize(mTimeFrameGPU->getNClustersLayer(rof0, iLayer))};
-      const dim3 blocksGrid{gpu::utils::host::getBlocksGrid(threadsPerBlock, mTimeFrameGPU->getNClustersLayer(rof0, iLayer))};
-      const float meanDeltaR{mTrkParams[iteration].LayerRadii[iLayer + 1] - mTrkParams[iteration].LayerRadii[iLayer]};
+  // for (int rof0{0}; rof0 < mTimeFrameGPU->getNrof(); ++rof0) {
+  //   gsl::span<const Vertex> primaryVertices = mTrkParams[iteration].UseDiamond ? diamondSpan : mTimeFrameGPU->getPrimaryVertices(rof0); // replace with GPU one
+  //   std::vector<Vertex> paddedVertices;
+  //   for (int iVertex{0}; iVertex < mTimeFrameGPU->getConfig().maxVerticesCapacity; ++iVertex) {
+  //     if (iVertex < primaryVertices.size()) {
+  //       paddedVertices.emplace_back(primaryVertices[iVertex]);
+  //     } else {
+  //       paddedVertices.emplace_back(Vertex());
+  //     }
+  //   }
+  //   checkGPUError(cudaMemcpy(mTimeFrameGPU->getDeviceVertices(rof0), paddedVertices.data(), mTimeFrameGPU->getConfig().maxVerticesCapacity * sizeof(Vertex), cudaMemcpyHostToDevice), __FILE__, __LINE__);
+  //   for (int iLayer{0}; iLayer < NLayers - 1; ++iLayer) {
+  //     const dim3 threadsPerBlock{gpu::utils::host::getBlockSize(mTimeFrameGPU->getNClustersLayer(rof0, iLayer))};
+  //     const dim3 blocksGrid{gpu::utils::host::getBlocksGrid(threadsPerBlock, mTimeFrameGPU->getNClustersLayer(rof0, iLayer))};
+  //     const float meanDeltaR{mTrkParams[iteration].LayerRadii[iLayer + 1] - mTrkParams[iteration].LayerRadii[iLayer]};
 
-      if (!mTimeFrameGPU->getClustersOnLayer(rof0, iLayer).size()) {
-        LOGP(info, "Skipping ROF0: {}, no clusters found on layer {}", rof0, iLayer);
-        continue;
-      }
+  //     if (!mTimeFrameGPU->getClustersOnLayer(rof0, iLayer).size()) {
+  //       LOGP(info, "Skipping ROF0: {}, no clusters found on layer {}", rof0, iLayer);
+  //       continue;
+  //     }
 
-      gpu::computeLayerTrackletsKernel<<<blocksGrid, threadsPerBlock, 0, mTimeFrameGPU->getStream(iLayer).get()>>>(
-        rof0,
-        mTimeFrameGPU->getNrof(),
-        iLayer,
-        mTimeFrameGPU->getDeviceClustersOnLayer(rof0, iLayer),       // :checked:
-        mTimeFrameGPU->getDeviceClustersOnLayer(0, iLayer + 1),      // :checked:
-        mTimeFrameGPU->getDeviceIndexTables(iLayer + 1),             // :checked:
-        mTimeFrameGPU->getDeviceROframesClustersOnLayer(iLayer),     // :checked:
-        mTimeFrameGPU->getDeviceROframesClustersOnLayer(iLayer + 1), // :checked:
-        mTimeFrameGPU->getDeviceUsedClustersOnLayer(0, iLayer),      // :checked:
-        mTimeFrameGPU->getDeviceUsedClustersOnLayer(0, iLayer + 1),  // :checked:
-        mTimeFrameGPU->getDeviceVertices(rof0),
-        mTimeFrameGPU->getDeviceTrackletsLookupTable(0, iLayer),
-        mTimeFrameGPU->getDeviceTracklets(rof0, iLayer),
-        mTimeFrameGPU->getConfig().maxVerticesCapacity,
-        mTimeFrameGPU->getNClustersLayer(rof0, iLayer),
-        mTimeFrameGPU->getPhiCut(iLayer),
-        mTimeFrameGPU->getMinR(iLayer + 1),
-        mTimeFrameGPU->getMaxR(iLayer + 1),
-        meanDeltaR,
-        mTimeFrameGPU->getPositionResolution(iLayer),
-        mTimeFrameGPU->getMSangle(iLayer),
-        mTimeFrameGPU->getDeviceTrackingParameters(),
-        mTimeFrameGPU->getDeviceIndexTableUtils(),
-        mTimeFrameGPU->getConfig().maxTrackletsPerCluster);
-    }
-  }
+  //     gpu::computeLayerTrackletsKernel<<<blocksGrid, threadsPerBlock, 0, mTimeFrameGPU->getStream(iLayer).get()>>>(
+  //       rof0,
+  //       mTimeFrameGPU->getNrof(),
+  //       iLayer,
+  //       mTimeFrameGPU->getDeviceClustersOnLayer(rof0, iLayer),       // :checked:
+  //       mTimeFrameGPU->getDeviceClustersOnLayer(0, iLayer + 1),      // :checked:
+  //       mTimeFrameGPU->getDeviceIndexTables(iLayer + 1),             // :checked:
+  //       mTimeFrameGPU->getDeviceROframesClustersOnLayer(iLayer),     // :checked:
+  //       mTimeFrameGPU->getDeviceROframesClustersOnLayer(iLayer + 1), // :checked:
+  //       mTimeFrameGPU->getDeviceUsedClustersOnLayer(0, iLayer),      // :checked:
+  //       mTimeFrameGPU->getDeviceUsedClustersOnLayer(0, iLayer + 1),  // :checked:
+  //       mTimeFrameGPU->getDeviceVertices(rof0),
+  //       mTimeFrameGPU->getDeviceTrackletsLookupTable(0, iLayer),
+  //       mTimeFrameGPU->getDeviceTracklets(rof0, iLayer),
+  //       mTimeFrameGPU->getConfig().maxVerticesCapacity,
+  //       mTimeFrameGPU->getNClustersLayer(rof0, iLayer),
+  //       mTimeFrameGPU->getPhiCut(iLayer),
+  //       mTimeFrameGPU->getMinR(iLayer + 1),
+  //       mTimeFrameGPU->getMaxR(iLayer + 1),
+  //       meanDeltaR,
+  //       mTimeFrameGPU->getPositionResolution(iLayer),
+  //       mTimeFrameGPU->getMSangle(iLayer),
+  //       mTimeFrameGPU->getDeviceTrackingParameters(),
+  //       mTimeFrameGPU->getDeviceIndexTableUtils(),
+  //       mTimeFrameGPU->getConfig().maxTrackletsPerCluster);
+  //   }
+  // }
 
-  for (int iLayer{0}; iLayer < NLayers - 1; ++iLayer) {
-    // Sort tracklets to put empty ones on the right side of the array.
-    auto thrustTrackletsBegin = thrust::device_ptr<o2::its::Tracklet>(mTimeFrameGPU->getDeviceTrackletsAll(iLayer));
-    auto thrustTrackletsEnd = thrust::device_ptr<o2::its::Tracklet>(mTimeFrameGPU->getDeviceTrackletsAll(iLayer) + mTimeFrameGPU->getConfig().trackletsCapacity);
-    thrust::sort(thrustTrackletsBegin, thrustTrackletsEnd, gpu::trackletSortEmptyFunctor<o2::its::Tracklet>());
+  // for (int iLayer{0}; iLayer < NLayers - 1; ++iLayer) {
+  //   // Sort tracklets to put empty ones on the right side of the array.
+  //   auto thrustTrackletsBegin = thrust::device_ptr<o2::its::Tracklet>(mTimeFrameGPU->getDeviceTrackletsAll(iLayer));
+  //   auto thrustTrackletsEnd = thrust::device_ptr<o2::its::Tracklet>(mTimeFrameGPU->getDeviceTrackletsAll(iLayer) + mTimeFrameGPU->getConfig().trackletsCapacity);
+  //   thrust::sort(thrustTrackletsBegin, thrustTrackletsEnd, gpu::trackletSortEmptyFunctor<o2::its::Tracklet>());
 
-    // Get number of found tracklets
-    // With thrust:
-    // auto thrustTrackletsLUTbegin = thrust::device_ptr<int>(mTimeFrameGPU->getDeviceTrackletsLookupTable(0, iLayer));
-    // auto thrustTrackletsLUTend = thrust::device_ptr<int>(mTimeFrameGPU->getDeviceTrackletsLookupTable(0, iLayer) + mTimeFrameGPU->mClusters[iLayer].size());
-    // mTimeFrameGPU->getTrackletSizeHost()[iLayer] = thrust::reduce(thrustTrackletsLUTbegin, thrustTrackletsLUTend, 0);
+  //   // Get number of found tracklets
+  //   // With thrust:
+  //   // auto thrustTrackletsLUTbegin = thrust::device_ptr<int>(mTimeFrameGPU->getDeviceTrackletsLookupTable(0, iLayer));
+  //   // auto thrustTrackletsLUTend = thrust::device_ptr<int>(mTimeFrameGPU->getDeviceTrackletsLookupTable(0, iLayer) + mTimeFrameGPU->mClusters[iLayer].size());
+  //   // mTimeFrameGPU->getTrackletSizeHost()[iLayer] = thrust::reduce(thrustTrackletsLUTbegin, thrustTrackletsLUTend, 0);
 
-    discardResult(cub::DeviceReduce::Sum(reinterpret_cast<void*>(mTimeFrameGPU->getDeviceCUBBuffer(iLayer)), // d_temp_storage
-                                         bufferSize,                                                         // temp_storage_bytes
-                                         mTimeFrameGPU->getDeviceTrackletsLookupTable(0, iLayer),            // d_in
-                                         mTimeFrameGPU->getDeviceNFoundTracklets() + iLayer,                 // d_out
-                                         mTimeFrameGPU->mClusters[iLayer].size(),                            // num_items
-                                         mTimeFrameGPU->getStream(iLayer).get()));
-  }
-  discardResult(cudaDeviceSynchronize());
-  checkGPUError(cudaMemcpy(mTimeFrameGPU->getTrackletSizeHost().data(), mTimeFrameGPU->getDeviceNFoundTracklets(), (NLayers - 1) * sizeof(int), cudaMemcpyDeviceToHost), __FILE__, __LINE__);
-  for (int iLayer{0}; iLayer < NLayers - 1; ++iLayer) {
+  //   discardResult(cub::DeviceReduce::Sum(reinterpret_cast<void*>(mTimeFrameGPU->getDeviceCUBBuffer(iLayer)), // d_temp_storage
+  //                                        bufferSize,                                                         // temp_storage_bytes
+  //                                        mTimeFrameGPU->getDeviceTrackletsLookupTable(0, iLayer),            // d_in
+  //                                        mTimeFrameGPU->getDeviceNFoundTracklets() + iLayer,                 // d_out
+  //                                        mTimeFrameGPU->mClusters[iLayer].size(),                            // num_items
+  //                                        mTimeFrameGPU->getStream(iLayer).get()));
+  // }
+  // discardResult(cudaDeviceSynchronize());
+  // checkGPUError(cudaMemcpy(mTimeFrameGPU->getTrackletSizeHost().data(), mTimeFrameGPU->getDeviceNFoundTracklets(), (NLayers - 1) * sizeof(int), cudaMemcpyDeviceToHost), __FILE__, __LINE__);
+  // for (int iLayer{0}; iLayer < NLayers - 1; ++iLayer) {
 
-    // Sort tracklets according to cluster ids
-    auto thrustTrackletsBegin = thrust::device_ptr<o2::its::Tracklet>(mTimeFrameGPU->getDeviceTrackletsAll(iLayer));
-    auto thrustTrackletsEnd = thrust::device_ptr<o2::its::Tracklet>(mTimeFrameGPU->getDeviceTrackletsAll(iLayer) + mTimeFrameGPU->getTrackletSizeHost()[iLayer]);
-    thrust::sort(thrustTrackletsBegin, thrustTrackletsEnd, gpu::trackletSortIndexFunctor<o2::its::Tracklet>());
-  }
-  discardResult(cudaDeviceSynchronize());
-  for (int iLayer{0}; iLayer < NLayers - 1; ++iLayer) {
-    // Remove duplicate entries in LUTs, done by single thread so far
-    gpu::removeDuplicateTrackletsEntriesLUTKernel<<<1, 1, 0, mTimeFrameGPU->getStream(iLayer).get()>>>(
-      mTimeFrameGPU->getDeviceTrackletsLookupTable(0, iLayer),
-      mTimeFrameGPU->getDeviceTrackletsAll(iLayer),
-      mTimeFrameGPU->getDeviceNFoundTracklets(),
-      iLayer);
-  }
-  // Remove actual tracklet duplicates
-  for (int iLayer{0}; iLayer < NLayers - 1; ++iLayer) {
-    auto begin = thrust::device_ptr<o2::its::Tracklet>(mTimeFrameGPU->getDeviceTrackletsAll(iLayer));
-    auto end = thrust::device_ptr<o2::its::Tracklet>(mTimeFrameGPU->getDeviceTrackletsAll(iLayer) + mTimeFrameGPU->getTrackletSizeHost()[iLayer]);
+  //   // Sort tracklets according to cluster ids
+  //   auto thrustTrackletsBegin = thrust::device_ptr<o2::its::Tracklet>(mTimeFrameGPU->getDeviceTrackletsAll(iLayer));
+  //   auto thrustTrackletsEnd = thrust::device_ptr<o2::its::Tracklet>(mTimeFrameGPU->getDeviceTrackletsAll(iLayer) + mTimeFrameGPU->getTrackletSizeHost()[iLayer]);
+  //   thrust::sort(thrustTrackletsBegin, thrustTrackletsEnd, gpu::trackletSortIndexFunctor<o2::its::Tracklet>());
+  // }
+  // discardResult(cudaDeviceSynchronize());
+  // for (int iLayer{0}; iLayer < NLayers - 1; ++iLayer) {
+  //   // Remove duplicate entries in LUTs, done by single thread so far
+  //   gpu::removeDuplicateTrackletsEntriesLUTKernel<<<1, 1, 0, mTimeFrameGPU->getStream(iLayer).get()>>>(
+  //     mTimeFrameGPU->getDeviceTrackletsLookupTable(0, iLayer),
+  //     mTimeFrameGPU->getDeviceTrackletsAll(iLayer),
+  //     mTimeFrameGPU->getDeviceNFoundTracklets(),
+  //     iLayer);
+  // }
+  // // Remove actual tracklet duplicates
+  // for (int iLayer{0}; iLayer < NLayers - 1; ++iLayer) {
+  //   auto begin = thrust::device_ptr<o2::its::Tracklet>(mTimeFrameGPU->getDeviceTrackletsAll(iLayer));
+  //   auto end = thrust::device_ptr<o2::its::Tracklet>(mTimeFrameGPU->getDeviceTrackletsAll(iLayer) + mTimeFrameGPU->getTrackletSizeHost()[iLayer]);
 
-    auto new_end = thrust::unique(begin, end);
-    mTimeFrameGPU->getTrackletSizeHost()[iLayer] = new_end - begin;
-  }
-  discardResult(cudaDeviceSynchronize());
-  for (int iLayer{0}; iLayer < NLayers - 1; ++iLayer) {
-    // Compute LUT
-    discardResult(cub::DeviceScan::ExclusiveSum(reinterpret_cast<void*>(mTimeFrameGPU->getDeviceCUBBuffer(iLayer)), // d_temp_storage
-                                                bufferSize,                                                         // temp_storage_bytes
-                                                mTimeFrameGPU->getDeviceTrackletsLookupTable(0, iLayer),            // d_in
-                                                mTimeFrameGPU->getDeviceTrackletsLookupTable(0, iLayer),            // d_out
-                                                mTimeFrameGPU->mClusters[iLayer].size(),                            // num_items
-                                                mTimeFrameGPU->getStream(iLayer).get()));
-  }
-  discardResult(cudaDeviceSynchronize());
+  //   auto new_end = thrust::unique(begin, end);
+  //   mTimeFrameGPU->getTrackletSizeHost()[iLayer] = new_end - begin;
+  // }
+  // discardResult(cudaDeviceSynchronize());
+  // for (int iLayer{0}; iLayer < NLayers - 1; ++iLayer) {
+  //   // Compute LUT
+  //   discardResult(cub::DeviceScan::ExclusiveSum(reinterpret_cast<void*>(mTimeFrameGPU->getDeviceCUBBuffer(iLayer)), // d_temp_storage
+  //                                               bufferSize,                                                         // temp_storage_bytes
+  //                                               mTimeFrameGPU->getDeviceTrackletsLookupTable(0, iLayer),            // d_in
+  //                                               mTimeFrameGPU->getDeviceTrackletsLookupTable(0, iLayer),            // d_out
+  //                                               mTimeFrameGPU->mClusters[iLayer].size(),                            // num_items
+  //                                               mTimeFrameGPU->getStream(iLayer).get()));
+  // }
+  // discardResult(cudaDeviceSynchronize());
 
-  // Create tracklets labels, at the moment on the host
-  if (mTimeFrameGPU->hasMCinformation()) {
-    for (int iLayer{0}; iLayer < mTrkParams[iteration].TrackletsPerRoad(); ++iLayer) {
-      std::vector<o2::its::Tracklet> tracklets(mTimeFrameGPU->getTrackletSizeHost()[iLayer]);
-      checkGPUError(cudaMemcpy(tracklets.data(), mTimeFrameGPU->getDeviceTrackletsAll(iLayer), mTimeFrameGPU->getTrackletSizeHost()[iLayer] * sizeof(o2::its::Tracklet), cudaMemcpyDeviceToHost), __FILE__, __LINE__);
-      for (auto& trk : tracklets) {
-        MCCompLabel label;
-        int currentId{mTimeFrameGPU->mClusters[iLayer][trk.firstClusterIndex].clusterId};
-        int nextId{mTimeFrameGPU->mClusters[iLayer + 1][trk.secondClusterIndex].clusterId};
-        for (auto& lab1 : mTimeFrameGPU->getClusterLabels(iLayer, currentId)) {
-          for (auto& lab2 : mTimeFrameGPU->getClusterLabels(iLayer + 1, nextId)) {
-            if (lab1 == lab2 && lab1.isValid()) {
-              label = lab1;
-              break;
-            }
-          }
-          if (label.isValid()) {
-            break;
-          }
-        }
-        mTimeFrameGPU->getTrackletsLabel(iLayer).emplace_back(label);
-      }
-    }
-  }
+  // // Create tracklets labels, at the moment on the host
+  // if (mTimeFrameGPU->hasMCinformation()) {
+  //   for (int iLayer{0}; iLayer < mTrkParams[iteration].TrackletsPerRoad(); ++iLayer) {
+  //     std::vector<o2::its::Tracklet> tracklets(mTimeFrameGPU->getTrackletSizeHost()[iLayer]);
+  //     checkGPUError(cudaMemcpy(tracklets.data(), mTimeFrameGPU->getDeviceTrackletsAll(iLayer), mTimeFrameGPU->getTrackletSizeHost()[iLayer] * sizeof(o2::its::Tracklet), cudaMemcpyDeviceToHost), __FILE__, __LINE__);
+  //     for (auto& trk : tracklets) {
+  //       MCCompLabel label;
+  //       int currentId{mTimeFrameGPU->mClusters[iLayer][trk.firstClusterIndex].clusterId};
+  //       int nextId{mTimeFrameGPU->mClusters[iLayer + 1][trk.secondClusterIndex].clusterId};
+  //       for (auto& lab1 : mTimeFrameGPU->getClusterLabels(iLayer, currentId)) {
+  //         for (auto& lab2 : mTimeFrameGPU->getClusterLabels(iLayer + 1, nextId)) {
+  //           if (lab1 == lab2 && lab1.isValid()) {
+  //             label = lab1;
+  //             break;
+  //           }
+  //         }
+  //         if (label.isValid()) {
+  //           break;
+  //         }
+  //       }
+  //       mTimeFrameGPU->getTrackletsLabel(iLayer).emplace_back(label);
+  //     }
+  //   }
+  // }
 }
 
 template <int NLayers>
 void TrackerTraitsGPU<NLayers>::computeLayerCells(const int iteration)
 {
-  size_t bufferSize = mTimeFrameGPU->getConfig().tmpCUBBufferSize;
-  for (int iLayer{0}; iLayer < NLayers - 2; ++iLayer) {
-    if (!mTimeFrameGPU->getTrackletSizeHost()[iLayer + 1] ||
-        !mTimeFrameGPU->getTrackletSizeHost()[iLayer]) {
-      continue;
-    }
-    const dim3 threadsPerBlock{gpu::utils::host::getBlockSize(mTimeFrameGPU->getTrackletSizeHost()[iLayer])};
-    const dim3 blocksGrid{gpu::utils::host::getBlocksGrid(threadsPerBlock, mTimeFrameGPU->getTrackletSizeHost()[iLayer])};
-    gpu::computeLayerCellsKernel<true><<<blocksGrid, threadsPerBlock, 0, mTimeFrameGPU->getStream(iLayer).get()>>>(
-      mTimeFrameGPU->getDeviceTrackletsAll(iLayer),
-      mTimeFrameGPU->getDeviceTrackletsAll(iLayer + 1),
-      mTimeFrameGPU->getDeviceTrackletsLookupTable(0, iLayer + 1),
-      mTimeFrameGPU->getTrackletSizeHost()[iLayer],
-      nullptr,
-      mTimeFrameGPU->getDeviceCellsLookupTable(iLayer),
-      mTimeFrameGPU->getDeviceTrackingParameters());
+  // size_t bufferSize = mTimeFrameGPU->getConfig().tmpCUBBufferSize;
+  // for (int iLayer{0}; iLayer < NLayers - 2; ++iLayer) {
+  //   if (!mTimeFrameGPU->getTrackletSizeHost()[iLayer + 1] ||
+  //       !mTimeFrameGPU->getTrackletSizeHost()[iLayer]) {
+  //     continue;
+  //   }
+  //   const dim3 threadsPerBlock{gpu::utils::host::getBlockSize(mTimeFrameGPU->getTrackletSizeHost()[iLayer])};
+  //   const dim3 blocksGrid{gpu::utils::host::getBlocksGrid(threadsPerBlock, mTimeFrameGPU->getTrackletSizeHost()[iLayer])};
+  //   gpu::computeLayerCellsKernel<true><<<blocksGrid, threadsPerBlock, 0, mTimeFrameGPU->getStream(iLayer).get()>>>(
+  //     mTimeFrameGPU->getDeviceTrackletsAll(iLayer),
+  //     mTimeFrameGPU->getDeviceTrackletsAll(iLayer + 1),
+  //     mTimeFrameGPU->getDeviceTrackletsLookupTable(0, iLayer + 1),
+  //     mTimeFrameGPU->getTrackletSizeHost()[iLayer],
+  //     nullptr,
+  //     mTimeFrameGPU->getDeviceCellsLookupTable(iLayer),
+  //     mTimeFrameGPU->getDeviceTrackingParameters());
 
-    // Compute number of found Cells
-    discardResult(cub::DeviceReduce::Sum(reinterpret_cast<void*>(mTimeFrameGPU->getDeviceCUBBuffer(iLayer)), // d_temp_storage
-                                         bufferSize,                                                         // temp_storage_bytes
-                                         mTimeFrameGPU->getDeviceCellsLookupTable(iLayer),                   // d_in
-                                         mTimeFrameGPU->getDeviceNFoundCells() + iLayer,                     // d_out
-                                         mTimeFrameGPU->getTrackletSizeHost()[iLayer],                       // num_items
-                                         mTimeFrameGPU->getStream(iLayer).get()));
+  //   // Compute number of found Cells
+  //   discardResult(cub::DeviceReduce::Sum(reinterpret_cast<void*>(mTimeFrameGPU->getDeviceCUBBuffer(iLayer)), // d_temp_storage
+  //                                        bufferSize,                                                         // temp_storage_bytes
+  //                                        mTimeFrameGPU->getDeviceCellsLookupTable(iLayer),                   // d_in
+  //                                        mTimeFrameGPU->getDeviceNFoundCells() + iLayer,                     // d_out
+  //                                        mTimeFrameGPU->getTrackletSizeHost()[iLayer],                       // num_items
+  //                                        mTimeFrameGPU->getStream(iLayer).get()));
 
-    // Compute LUT
-    discardResult(cub::DeviceScan::ExclusiveSum(reinterpret_cast<void*>(mTimeFrameGPU->getDeviceCUBBuffer(iLayer)), // d_temp_storage
-                                                bufferSize,                                                         // temp_storage_bytes
-                                                mTimeFrameGPU->getDeviceCellsLookupTable(iLayer),                   // d_in
-                                                mTimeFrameGPU->getDeviceCellsLookupTable(iLayer),                   // d_out
-                                                mTimeFrameGPU->getTrackletSizeHost()[iLayer],                       // num_items
-                                                mTimeFrameGPU->getStream(iLayer).get()));
-    discardResult(cudaStreamSynchronize(mTimeFrameGPU->getStream(iLayer).get()));
+  //   // Compute LUT
+  //   discardResult(cub::DeviceScan::ExclusiveSum(reinterpret_cast<void*>(mTimeFrameGPU->getDeviceCUBBuffer(iLayer)), // d_temp_storage
+  //                                               bufferSize,                                                         // temp_storage_bytes
+  //                                               mTimeFrameGPU->getDeviceCellsLookupTable(iLayer),                   // d_in
+  //                                               mTimeFrameGPU->getDeviceCellsLookupTable(iLayer),                   // d_out
+  //                                               mTimeFrameGPU->getTrackletSizeHost()[iLayer],                       // num_items
+  //                                               mTimeFrameGPU->getStream(iLayer).get()));
+  //   discardResult(cudaStreamSynchronize(mTimeFrameGPU->getStream(iLayer).get()));
 
-    gpu::computeLayerCellsKernel<false><<<blocksGrid, threadsPerBlock, 0, mTimeFrameGPU->getStream(iLayer).get()>>>(
-      mTimeFrameGPU->getDeviceTrackletsAll(iLayer),
-      mTimeFrameGPU->getDeviceTrackletsAll(iLayer + 1),
-      mTimeFrameGPU->getDeviceTrackletsLookupTable(0, iLayer + 1),
-      mTimeFrameGPU->getTrackletSizeHost()[iLayer],
-      mTimeFrameGPU->getDeviceCells(iLayer),
-      mTimeFrameGPU->getDeviceCellsLookupTable(iLayer),
-      mTimeFrameGPU->getDeviceTrackingParameters());
-  }
+  //   gpu::computeLayerCellsKernel<false><<<blocksGrid, threadsPerBlock, 0, mTimeFrameGPU->getStream(iLayer).get()>>>(
+  //     mTimeFrameGPU->getDeviceTrackletsAll(iLayer),
+  //     mTimeFrameGPU->getDeviceTrackletsAll(iLayer + 1),
+  //     mTimeFrameGPU->getDeviceTrackletsLookupTable(0, iLayer + 1),
+  //     mTimeFrameGPU->getTrackletSizeHost()[iLayer],
+  //     mTimeFrameGPU->getDeviceCells(iLayer),
+  //     mTimeFrameGPU->getDeviceCellsLookupTable(iLayer),
+  //     mTimeFrameGPU->getDeviceTrackingParameters());
+  // }
 
-  checkGPUError(cudaMemcpy(mTimeFrameGPU->getCellSizeHost().data(), mTimeFrameGPU->getDeviceNFoundCells(), (NLayers - 2) * sizeof(int), cudaMemcpyDeviceToHost), __FILE__, __LINE__);
-  /// Create cells labels
-  if (mTimeFrameGPU->hasMCinformation()) {
-    for (int iLayer{0}; iLayer < NLayers - 2; ++iLayer) {
-      std::vector<o2::its::Cell> cells(mTimeFrameGPU->getCellSizeHost()[iLayer]);
-      checkGPUError(cudaMemcpy(cells.data(), mTimeFrameGPU->getDeviceCells(iLayer), mTimeFrameGPU->getCellSizeHost()[iLayer] * sizeof(o2::its::Cell), cudaMemcpyDeviceToHost), __FILE__, __LINE__);
-      for (auto& cell : cells) {
-        MCCompLabel currentLab{mTimeFrameGPU->getTrackletsLabel(iLayer)[cell.getFirstTrackletIndex()]};
-        MCCompLabel nextLab{mTimeFrameGPU->getTrackletsLabel(iLayer + 1)[cell.getSecondTrackletIndex()]};
-        mTimeFrameGPU->getCellsLabel(iLayer).emplace_back(currentLab == nextLab ? currentLab : MCCompLabel());
-      }
-    }
-  }
+  // checkGPUError(cudaMemcpy(mTimeFrameGPU->getCellSizeHost().data(), mTimeFrameGPU->getDeviceNFoundCells(), (NLayers - 2) * sizeof(int), cudaMemcpyDeviceToHost), __FILE__, __LINE__);
+  // /// Create cells labels
+  // if (mTimeFrameGPU->hasMCinformation()) {
+  //   for (int iLayer{0}; iLayer < NLayers - 2; ++iLayer) {
+  //     std::vector<o2::its::Cell> cells(mTimeFrameGPU->getCellSizeHost()[iLayer]);
+  //     checkGPUError(cudaMemcpy(cells.data(), mTimeFrameGPU->getDeviceCells(iLayer), mTimeFrameGPU->getCellSizeHost()[iLayer] * sizeof(o2::its::Cell), cudaMemcpyDeviceToHost), __FILE__, __LINE__);
+  //     for (auto& cell : cells) {
+  //       MCCompLabel currentLab{mTimeFrameGPU->getTrackletsLabel(iLayer)[cell.getFirstTrackletIndex()]};
+  //       MCCompLabel nextLab{mTimeFrameGPU->getTrackletsLabel(iLayer + 1)[cell.getSecondTrackletIndex()]};
+  //       mTimeFrameGPU->getCellsLabel(iLayer).emplace_back(currentLab == nextLab ? currentLab : MCCompLabel());
+  //     }
+  //   }
+  // }
 }
 
 // void TrackerTraitsGPU::refitTracks(const std::vector<std::vector<TrackingFrameInfo>>& tf, std::vector<TrackITSExt>& tracks)

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TrackerTraitsGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TrackerTraitsGPU.cu
@@ -35,7 +35,7 @@ namespace o2
 {
 namespace its
 {
-using gpu::utils::host::checkGPUError;
+using gpu::utils::checkGPUError;
 using namespace constants::its2;
 
 namespace gpu
@@ -274,8 +274,8 @@ void TrackerTraitsGPU<NLayers>::computeLayerTracklets(const int iteration)
   //   }
   //   checkGPUError(cudaMemcpy(mTimeFrameGPU->getDeviceVertices(rof0), paddedVertices.data(), mTimeFrameGPU->getConfig().maxVerticesCapacity * sizeof(Vertex), cudaMemcpyHostToDevice), __FILE__, __LINE__);
   //   for (int iLayer{0}; iLayer < NLayers - 1; ++iLayer) {
-  //     const dim3 threadsPerBlock{gpu::utils::host::getBlockSize(mTimeFrameGPU->getNClustersLayer(rof0, iLayer))};
-  //     const dim3 blocksGrid{gpu::utils::host::getBlocksGrid(threadsPerBlock, mTimeFrameGPU->getNClustersLayer(rof0, iLayer))};
+  //     const dim3 threadsPerBlock{gpu::utils::getBlockSize(mTimeFrameGPU->getNClustersLayer(rof0, iLayer))};
+  //     const dim3 blocksGrid{gpu::utils::getBlocksGrid(threadsPerBlock, mTimeFrameGPU->getNClustersLayer(rof0, iLayer))};
   //     const float meanDeltaR{mTrkParams[iteration].LayerRadii[iLayer + 1] - mTrkParams[iteration].LayerRadii[iLayer]};
 
   //     if (!mTimeFrameGPU->getClustersOnLayer(rof0, iLayer).size()) {
@@ -403,8 +403,8 @@ void TrackerTraitsGPU<NLayers>::computeLayerCells(const int iteration)
   //       !mTimeFrameGPU->getTrackletSizeHost()[iLayer]) {
   //     continue;
   //   }
-  //   const dim3 threadsPerBlock{gpu::utils::host::getBlockSize(mTimeFrameGPU->getTrackletSizeHost()[iLayer])};
-  //   const dim3 blocksGrid{gpu::utils::host::getBlocksGrid(threadsPerBlock, mTimeFrameGPU->getTrackletSizeHost()[iLayer])};
+  //   const dim3 threadsPerBlock{gpu::utils::getBlockSize(mTimeFrameGPU->getTrackletSizeHost()[iLayer])};
+  //   const dim3 blocksGrid{gpu::utils::getBlocksGrid(threadsPerBlock, mTimeFrameGPU->getTrackletSizeHost()[iLayer])};
   //   gpu::computeLayerCellsKernel<true><<<blocksGrid, threadsPerBlock, 0, mTimeFrameGPU->getStream(iLayer).get()>>>(
   //     mTimeFrameGPU->getDeviceTrackletsAll(iLayer),
   //     mTimeFrameGPU->getDeviceTrackletsAll(iLayer + 1),

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/Utils.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/Utils.cu
@@ -11,10 +11,13 @@
 
 #include "ITStrackingGPU/Utils.h"
 #include "ITStrackingGPU/Context.h"
+#include "ITStracking/Constants.h"
 
 #include <sstream>
 #include <stdexcept>
-
+#include <cstdio>
+#include <iomanip>
+#include <numeric>
 #include <iostream>
 
 namespace
@@ -53,6 +56,7 @@ namespace o2
 {
 namespace its
 {
+using constants::GB;
 namespace gpu
 {
 
@@ -67,7 +71,10 @@ GPUh() void gpuThrowOnError()
   }
 }
 
-void utils::host::checkGPUError(const cudaError_t error, const char* file, const int line)
+double bytesToconfig(size_t s) { return (double)s / (1024.0); }
+double bytesToGB(size_t s) { return (double)s / GB; }
+
+void utils::checkGPUError(const cudaError_t error, const char* file, const int line)
 {
   if (error != cudaSuccess) {
     std::ostringstream errorString{};
@@ -78,18 +85,139 @@ void utils::host::checkGPUError(const cudaError_t error, const char* file, const
   }
 }
 
-dim3 utils::host::getBlockSize(const int colsNum)
+void utils::getDeviceProp(int deviceId, bool print)
+{
+  const int w1 = 34;
+  std::cout << std::left;
+  std::cout << std::setw(w1)
+            << "--------------------------------------------------------------------------------"
+            << std::endl;
+  std::cout << std::setw(w1) << "device#" << deviceId << std::endl;
+
+  cudaDeviceProp props;
+  checkGPUError(cudaGetDeviceProperties(&props, deviceId));
+  if (print) {
+    std::cout << std::setw(w1) << "Name: " << props.name << std::endl;
+    std::cout << std::setw(w1) << "pciBusID: " << props.pciBusID << std::endl;
+    std::cout << std::setw(w1) << "pciDeviceID: " << props.pciDeviceID << std::endl;
+    std::cout << std::setw(w1) << "pciDomainID: " << props.pciDomainID << std::endl;
+    std::cout << std::setw(w1) << "multiProcessorCount: " << props.multiProcessorCount << std::endl;
+    std::cout << std::setw(w1) << "maxThreadsPerMultiProcessor: " << props.maxThreadsPerMultiProcessor
+              << std::endl;
+    std::cout << std::setw(w1) << "isMultiGpuBoard: " << props.isMultiGpuBoard << std::endl;
+    std::cout << std::setw(w1) << "clockRate: " << (float)props.clockRate / 1000.0 << " Mhz" << std::endl;
+    std::cout << std::setw(w1) << "memoryClockRate: " << (float)props.memoryClockRate / 1000.0 << " Mhz"
+              << std::endl;
+    std::cout << std::setw(w1) << "memoryBusWidth: " << props.memoryBusWidth << std::endl;
+    std::cout << std::setw(w1) << "clockInstructionRate: " << (float)props.clockRate / 1000.0
+              << " Mhz" << std::endl;
+    std::cout << std::setw(w1) << "totalGlobalMem: " << std::fixed << std::setprecision(2)
+              << bytesToGB(props.totalGlobalMem) << " GB" << std::endl;
+#if !defined(__CUDACC__)
+    std::cout << std::setw(w1) << "maxSharedMemoryPerMultiProcessor: " << std::fixed << std::setprecision(2)
+              << bytesToconfig(props.sharedMemPerMultiprocessor) << " config" << std::endl;
+#endif
+#if defined(__HIPCC__)
+    std::cout << std::setw(w1) << "maxSharedMemoryPerMultiProcessor: " << std::fixed << std::setprecision(2)
+              << bytesToconfig(props.maxSharedMemoryPerMultiProcessor) << " config" << std::endl;
+#endif
+    std::cout << std::setw(w1) << "totalConstMem: " << props.totalConstMem << std::endl;
+    std::cout << std::setw(w1) << "sharedMemPerBlock: " << (float)props.sharedMemPerBlock / 1024.0 << " config"
+              << std::endl;
+    std::cout << std::setw(w1) << "canMapHostMemory: " << props.canMapHostMemory << std::endl;
+    std::cout << std::setw(w1) << "regsPerBlock: " << props.regsPerBlock << std::endl;
+    std::cout << std::setw(w1) << "warpSize: " << props.warpSize << std::endl;
+    std::cout << std::setw(w1) << "l2CacheSize: " << props.l2CacheSize << std::endl;
+    std::cout << std::setw(w1) << "computeMode: " << props.computeMode << std::endl;
+    std::cout << std::setw(w1) << "maxThreadsPerBlock: " << props.maxThreadsPerBlock << std::endl;
+    std::cout << std::setw(w1) << "maxThreadsDim.x: " << props.maxThreadsDim[0] << std::endl;
+    std::cout << std::setw(w1) << "maxThreadsDim.y: " << props.maxThreadsDim[1] << std::endl;
+    std::cout << std::setw(w1) << "maxThreadsDim.z: " << props.maxThreadsDim[2] << std::endl;
+    std::cout << std::setw(w1) << "maxGridSize.x: " << props.maxGridSize[0] << std::endl;
+    std::cout << std::setw(w1) << "maxGridSize.y: " << props.maxGridSize[1] << std::endl;
+    std::cout << std::setw(w1) << "maxGridSize.z: " << props.maxGridSize[2] << std::endl;
+    std::cout << std::setw(w1) << "major: " << props.major << std::endl;
+    std::cout << std::setw(w1) << "minor: " << props.minor << std::endl;
+    std::cout << std::setw(w1) << "concurrentKernels: " << props.concurrentKernels << std::endl;
+    std::cout << std::setw(w1) << "cooperativeLaunch: " << props.cooperativeLaunch << std::endl;
+    std::cout << std::setw(w1) << "cooperativeMultiDeviceLaunch: " << props.cooperativeMultiDeviceLaunch << std::endl;
+#if defined(__HIPCC__)
+    std::cout << std::setw(w1) << "arch.hasGlobalInt32Atomics: " << props.arch.hasGlobalInt32Atomics << std::endl;
+    std::cout << std::setw(w1) << "arch.hasGlobalFloatAtomicExch: " << props.arch.hasGlobalFloatAtomicExch
+              << std::endl;
+    std::cout << std::setw(w1) << "arch.hasSharedInt32Atomics: " << props.arch.hasSharedInt32Atomics << std::endl;
+    std::cout << std::setw(w1) << "arch.hasSharedFloatAtomicExch: " << props.arch.hasSharedFloatAtomicExch
+              << std::endl;
+    std::cout << std::setw(w1) << "arch.hasFloatAtomicAdd: " << props.arch.hasFloatAtomicAdd << std::endl;
+    std::cout << std::setw(w1) << "arch.hasGlobalInt64Atomics: " << props.arch.hasGlobalInt64Atomics << std::endl;
+    std::cout << std::setw(w1) << "arch.hasSharedInt64Atomics: " << props.arch.hasSharedInt64Atomics << std::endl;
+    std::cout << std::setw(w1) << "arch.hasDoubles: " << props.arch.hasDoubles << std::endl;
+    std::cout << std::setw(w1) << "arch.hasWarpVote: " << props.arch.hasWarpVote << std::endl;
+    std::cout << std::setw(w1) << "arch.hasWarpBallot: " << props.arch.hasWarpBallot << std::endl;
+    std::cout << std::setw(w1) << "arch.hasWarpShuffle: " << props.arch.hasWarpShuffle << std::endl;
+    std::cout << std::setw(w1) << "arch.hasFunnelShift: " << props.arch.hasFunnelShift << std::endl;
+    std::cout << std::setw(w1) << "arch.hasThreadFenceSystem: " << props.arch.hasThreadFenceSystem << std::endl;
+    std::cout << std::setw(w1) << "arch.hasSyncThreadsExt: " << props.arch.hasSyncThreadsExt << std::endl;
+    std::cout << std::setw(w1) << "arch.hasSurfaceFuncs: " << props.arch.hasSurfaceFuncs << std::endl;
+    std::cout << std::setw(w1) << "arch.has3dGrid: " << props.arch.has3dGrid << std::endl;
+    std::cout << std::setw(w1) << "arch.hasDynamicParallelism: " << props.arch.hasDynamicParallelism << std::endl;
+    std::cout << std::setw(w1) << "gcnArchName: " << props.gcnArchName << std::endl;
+#endif
+    std::cout << std::setw(w1) << "isIntegrated: " << props.integrated << std::endl;
+    std::cout << std::setw(w1) << "maxTexture1D: " << props.maxTexture1D << std::endl;
+    std::cout << std::setw(w1) << "maxTexture2D.width: " << props.maxTexture2D[0] << std::endl;
+    std::cout << std::setw(w1) << "maxTexture2D.height: " << props.maxTexture2D[1] << std::endl;
+    std::cout << std::setw(w1) << "maxTexture3D.width: " << props.maxTexture3D[0] << std::endl;
+    std::cout << std::setw(w1) << "maxTexture3D.height: " << props.maxTexture3D[1] << std::endl;
+    std::cout << std::setw(w1) << "maxTexture3D.depth: " << props.maxTexture3D[2] << std::endl;
+#if defined(__HIPCC__)
+    std::cout << std::setw(w1) << "isLargeBar: " << props.isLargeBar << std::endl;
+    std::cout << std::setw(w1) << "asicRevision: " << props.asicRevision << std::endl;
+#endif
+
+    int deviceCnt;
+    checkGPUError(cudaGetDeviceCount(&deviceCnt));
+    std::cout << std::setw(w1) << "peers: ";
+    for (int i = 0; i < deviceCnt; i++) {
+      int isPeer;
+      checkGPUError(cudaDeviceCanAccessPeer(&isPeer, i, deviceId));
+      if (isPeer) {
+        std::cout << "device#" << i << " ";
+      }
+    }
+    std::cout << std::endl;
+    std::cout << std::setw(w1) << "non-peers: ";
+    for (int i = 0; i < deviceCnt; i++) {
+      int isPeer;
+      checkGPUError(cudaDeviceCanAccessPeer(&isPeer, i, deviceId));
+      if (!isPeer) {
+        std::cout << "device#" << i << " ";
+      }
+    }
+    std::cout << std::endl;
+
+    size_t free, total;
+    checkGPUError(cudaMemGetInfo(&free, &total));
+
+    std::cout << std::fixed << std::setprecision(2);
+    std::cout << std::setw(w1) << "memInfo.total: " << bytesToGB(total) << " GB" << std::endl;
+    std::cout << std::setw(w1) << "memInfo.free:  " << bytesToGB(free) << " GB (" << std::setprecision(0)
+              << (float)free / total * 100.0 << "%)" << std::endl;
+  }
+}
+
+dim3 utils::getBlockSize(const int colsNum)
 {
   return getBlockSize(colsNum, 1);
 }
 
-dim3 utils::host::getBlockSize(const int colsNum, const int rowsNum)
+dim3 utils::getBlockSize(const int colsNum, const int rowsNum)
 {
   const DeviceProperties& deviceProperties = Context::getInstance().getDeviceProperties();
   return getBlockSize(colsNum, rowsNum, deviceProperties.gpuCores / deviceProperties.maxBlocksPerSM);
 }
 
-dim3 utils::host::getBlockSize(const int colsNum, const int rowsNum, const int maxThreadsPerBlock)
+dim3 utils::getBlockSize(const int colsNum, const int rowsNum, const int maxThreadsPerBlock)
 {
   const DeviceProperties& deviceProperties = Context::getInstance().getDeviceProperties();
   int xThreads = max(min(colsNum, deviceProperties.maxThreadsDim.x), 1);
@@ -111,53 +239,53 @@ dim3 utils::host::getBlockSize(const int colsNum, const int rowsNum, const int m
   return dim3{static_cast<unsigned int>(xThreads), static_cast<unsigned int>(yThreads)};
 }
 
-dim3 utils::host::getBlocksGrid(const dim3& threadsPerBlock, const int rowsNum)
+dim3 utils::getBlocksGrid(const dim3& threadsPerBlock, const int rowsNum)
 {
   return getBlocksGrid(threadsPerBlock, rowsNum, 1);
 }
 
-dim3 utils::host::getBlocksGrid(const dim3& threadsPerBlock, const int rowsNum, const int colsNum)
+dim3 utils::getBlocksGrid(const dim3& threadsPerBlock, const int rowsNum, const int colsNum)
 {
 
   return dim3{1 + (rowsNum - 1) / threadsPerBlock.x, 1 + (colsNum - 1) / threadsPerBlock.y};
 }
 
-void utils::host::gpuMalloc(void** p, const int size)
+void utils::gpuMalloc(void** p, const int size)
 {
   checkGPUError(cudaMalloc(p, size), __FILE__, __LINE__);
 }
 
-void utils::host::gpuFree(void* p)
+void utils::gpuFree(void* p)
 {
   checkGPUError(cudaFree(p), __FILE__, __LINE__);
 }
 
-void utils::host::gpuMemset(void* p, int value, int size)
+void utils::gpuMemset(void* p, int value, int size)
 {
   checkGPUError(cudaMemset(p, value, size), __FILE__, __LINE__);
 }
 
-void utils::host::gpuMemcpyHostToDevice(void* dst, const void* src, int size)
+void utils::gpuMemcpyHostToDevice(void* dst, const void* src, int size)
 {
   checkGPUError(cudaMemcpy(dst, src, size, cudaMemcpyHostToDevice), __FILE__, __LINE__);
 }
 
-void utils::host::gpuMemcpyDeviceToHost(void* dst, const void* src, int size)
+void utils::gpuMemcpyDeviceToHost(void* dst, const void* src, int size)
 {
   checkGPUError(cudaMemcpy(dst, src, size, cudaMemcpyDeviceToHost), __FILE__, __LINE__);
 }
 
-void utils::host::gpuMemcpyToSymbol(const void* symbol, const void* src, int size)
+void utils::gpuMemcpyToSymbol(const void* symbol, const void* src, int size)
 {
   checkGPUError(cudaMemcpyToSymbol(symbol, src, size, 0, cudaMemcpyHostToDevice), __FILE__, __LINE__);
 }
 
-void utils::host::gpuMemcpyFromSymbol(void* dst, const void* symbol, int size)
+void utils::gpuMemcpyFromSymbol(void* dst, const void* symbol, int size)
 {
   checkGPUError(cudaMemcpyFromSymbol(dst, symbol, size, 0, cudaMemcpyDeviceToHost), __FILE__, __LINE__);
 }
 
-GPUd() int utils::device::getLaneIndex()
+GPUd() int utils::getLaneIndex()
 {
   uint32_t laneIndex;
   asm volatile("mov.u32 %0, %%laneid;"

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/Utils.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/Utils.cu
@@ -56,6 +56,17 @@ namespace its
 namespace gpu
 {
 
+GPUh() void gpuThrowOnError()
+{
+  cudaError_t error = cudaGetLastError();
+
+  if (error != cudaSuccess) {
+    std::ostringstream errorString{};
+    errorString << GPU_ARCH << " API returned error  [" << cudaGetErrorString(error) << "] (code " << error << ")" << std::endl;
+    throw std::runtime_error{errorString.str()};
+  }
+}
+
 void utils::host::checkGPUError(const cudaError_t error, const char* file, const int line)
 {
   if (error != cudaSuccess) {

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
@@ -96,7 +96,6 @@ void VertexerTraitsGPU::initialise(const TrackingParameters& trackingParams)
   }
   gpu::utils::host::gpuMemcpyHostToDevice(mDeviceIndexTableUtils, &mIndexTableUtils, sizeof(mIndexTableUtils));
   mTimeFrameGPU->initialise(0, trackingParams, 3);
-  setIsGPU(true);
 }
 
 namespace gpu

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
@@ -410,430 +410,430 @@ void VertexerTraitsGPU::updateVertexingParameters(const VertexingParameters& vrt
 
 void VertexerTraitsGPU::computeTracklets()
 {
-  if (!mTimeFrameGPU->getClusters().size()) {
-    return;
-  }
-  for (int rofId{0}; rofId < mTimeFrameGPU->getNrof(); ++rofId) {
-    const dim3 threadsPerBlock{gpu::utils::host::getBlockSize(mTimeFrameGPU->getNClustersLayer(rofId, 1))};
-    const dim3 blocksGrid{gpu::utils::host::getBlocksGrid(threadsPerBlock, mTimeFrameGPU->getNClustersLayer(rofId, 1))};
-    gpu::trackleterKernel<TrackletMode::Layer0Layer1><<<blocksGrid, threadsPerBlock, 0, mTimeFrameGPU->getStream(0).get()>>>(
-      mTimeFrameGPU->getDeviceClustersOnLayer(rofId, 0),
-      mTimeFrameGPU->getDeviceClustersOnLayer(rofId, 1),
-      mTimeFrameGPU->getNClustersLayer(rofId, 0),
-      mTimeFrameGPU->getNClustersLayer(rofId, 1),
-      mTimeFrameGPU->getDeviceIndexTableAtRof(0, rofId),
-      mVrtParams.phiCut,
-      mTimeFrameGPU->getDeviceTrackletsVertexerOnly(rofId, 0),
-      mTimeFrameGPU->getDeviceNTrackletsCluster(rofId, 0),
-      mDeviceIndexTableUtils,
-      rofId,
-      mVrtParams.maxTrackletsPerCluster);
-    gpu::trackleterKernel<TrackletMode::Layer1Layer2><<<blocksGrid, threadsPerBlock, 0, mTimeFrameGPU->getStream(1).get()>>>(
-      mTimeFrameGPU->getDeviceClustersOnLayer(rofId, 2),
-      mTimeFrameGPU->getDeviceClustersOnLayer(rofId, 1),
-      mTimeFrameGPU->getNClustersLayer(rofId, 2),
-      mTimeFrameGPU->getNClustersLayer(rofId, 1),
-      mTimeFrameGPU->getDeviceIndexTableAtRof(2, rofId),
-      mVrtParams.phiCut,
-      mTimeFrameGPU->getDeviceTrackletsVertexerOnly(rofId, 1),
-      mTimeFrameGPU->getDeviceNTrackletsCluster(rofId, 1),
-      mDeviceIndexTableUtils,
-      rofId,
-      mVrtParams.maxTrackletsPerCluster);
-  }
-#ifdef VTX_DEBUG
-  discardResult(cudaDeviceSynchronize());
-  std::ofstream out01("NTC01.txt"), out12("NTC12.txt");
-  std::vector<std::vector<int>> NtrackletsClusters01(mTimeFrameGPU->getNrof());
-  std::vector<std::vector<int>> NtrackletsClusters12(mTimeFrameGPU->getNrof());
-  for (int iRof{0}; iRof < mTimeFrameGPU->getNrof(); ++iRof) {
-    NtrackletsClusters01[iRof].resize(mTimeFrameGPU->getNClustersLayer(iRof, 1));
-    NtrackletsClusters12[iRof].resize(mTimeFrameGPU->getNClustersLayer(iRof, 1));
-    checkGPUError(cudaMemcpy(NtrackletsClusters01[iRof].data(),
-                             mTimeFrameGPU->getDeviceNTrackletsCluster(iRof, 0),
-                             sizeof(int) * mTimeFrameGPU->getNClustersLayer(iRof, 1),
-                             cudaMemcpyDeviceToHost),
-                  __FILE__, __LINE__);
-    checkGPUError(cudaMemcpy(NtrackletsClusters12[iRof].data(),
-                             mTimeFrameGPU->getDeviceNTrackletsCluster(iRof, 1),
-                             sizeof(int) * mTimeFrameGPU->getNClustersLayer(iRof, 1),
-                             cudaMemcpyDeviceToHost),
-                  __FILE__, __LINE__);
+//   if (!mTimeFrameGPU->getClusters().size()) {
+//     return;
+//   }
+//   for (int rofId{0}; rofId < mTimeFrameGPU->getNrof(); ++rofId) {
+//     const dim3 threadsPerBlock{gpu::utils::host::getBlockSize(mTimeFrameGPU->getNClustersLayer(rofId, 1))};
+//     const dim3 blocksGrid{gpu::utils::host::getBlocksGrid(threadsPerBlock, mTimeFrameGPU->getNClustersLayer(rofId, 1))};
+//     gpu::trackleterKernel<TrackletMode::Layer0Layer1><<<blocksGrid, threadsPerBlock, 0, mTimeFrameGPU->getStream(0).get()>>>(
+//       mTimeFrameGPU->getDeviceClustersOnLayer(rofId, 0),
+//       mTimeFrameGPU->getDeviceClustersOnLayer(rofId, 1),
+//       mTimeFrameGPU->getNClustersLayer(rofId, 0),
+//       mTimeFrameGPU->getNClustersLayer(rofId, 1),
+//       mTimeFrameGPU->getDeviceIndexTableAtRof(0, rofId),
+//       mVrtParams.phiCut,
+//       mTimeFrameGPU->getDeviceTrackletsVertexerOnly(rofId, 0),
+//       mTimeFrameGPU->getDeviceNTrackletsCluster(rofId, 0),
+//       mDeviceIndexTableUtils,
+//       rofId,
+//       mVrtParams.maxTrackletsPerCluster);
+//     gpu::trackleterKernel<TrackletMode::Layer1Layer2><<<blocksGrid, threadsPerBlock, 0, mTimeFrameGPU->getStream(1).get()>>>(
+//       mTimeFrameGPU->getDeviceClustersOnLayer(rofId, 2),
+//       mTimeFrameGPU->getDeviceClustersOnLayer(rofId, 1),
+//       mTimeFrameGPU->getNClustersLayer(rofId, 2),
+//       mTimeFrameGPU->getNClustersLayer(rofId, 1),
+//       mTimeFrameGPU->getDeviceIndexTableAtRof(2, rofId),
+//       mVrtParams.phiCut,
+//       mTimeFrameGPU->getDeviceTrackletsVertexerOnly(rofId, 1),
+//       mTimeFrameGPU->getDeviceNTrackletsCluster(rofId, 1),
+//       mDeviceIndexTableUtils,
+//       rofId,
+//       mVrtParams.maxTrackletsPerCluster);
+//   }
+// #ifdef VTX_DEBUG
+//   discardResult(cudaDeviceSynchronize());
+//   std::ofstream out01("NTC01.txt"), out12("NTC12.txt");
+//   std::vector<std::vector<int>> NtrackletsClusters01(mTimeFrameGPU->getNrof());
+//   std::vector<std::vector<int>> NtrackletsClusters12(mTimeFrameGPU->getNrof());
+//   for (int iRof{0}; iRof < mTimeFrameGPU->getNrof(); ++iRof) {
+//     NtrackletsClusters01[iRof].resize(mTimeFrameGPU->getNClustersLayer(iRof, 1));
+//     NtrackletsClusters12[iRof].resize(mTimeFrameGPU->getNClustersLayer(iRof, 1));
+//     checkGPUError(cudaMemcpy(NtrackletsClusters01[iRof].data(),
+//                              mTimeFrameGPU->getDeviceNTrackletsCluster(iRof, 0),
+//                              sizeof(int) * mTimeFrameGPU->getNClustersLayer(iRof, 1),
+//                              cudaMemcpyDeviceToHost),
+//                   __FILE__, __LINE__);
+//     checkGPUError(cudaMemcpy(NtrackletsClusters12[iRof].data(),
+//                              mTimeFrameGPU->getDeviceNTrackletsCluster(iRof, 1),
+//                              sizeof(int) * mTimeFrameGPU->getNClustersLayer(iRof, 1),
+//                              cudaMemcpyDeviceToHost),
+//                   __FILE__, __LINE__);
 
-    std::copy(NtrackletsClusters01[iRof].begin(), NtrackletsClusters01[iRof].end(), std::ostream_iterator<double>(out01, "\t"));
-    std::copy(NtrackletsClusters12[iRof].begin(), NtrackletsClusters12[iRof].end(), std::ostream_iterator<double>(out12, "\t"));
-    out01 << std::endl;
-    out12 << std::endl;
-  }
-  out01.close();
-  out12.close();
-  // Dump lines on root file
-  TFile* trackletFile = TFile::Open("artefacts_tf_gpu.root", "recreate");
-  TTree* tr_tre = new TTree("tracklets", "tf");
-  std::vector<o2::its::Tracklet> tracklets01;
-  std::vector<o2::its::Tracklet> tracklets12;
-  tr_tre->Branch("Tracklets0", &tracklets01);
-  tr_tre->Branch("Tracklets1", &tracklets12);
-  for (int iRof{0}; iRof < mTimeFrameGPU->getNrof(); ++iRof) {
-    tracklets01.clear();
-    tracklets12.clear();
-    std::vector<o2::its::Tracklet> rawTracklets0(mTimeFrameGPU->getNClustersLayer(iRof, 1) * mVrtParams.maxTrackletsPerCluster);
-    std::vector<o2::its::Tracklet> rawTracklets1(mTimeFrameGPU->getNClustersLayer(iRof, 1) * mVrtParams.maxTrackletsPerCluster);
-    checkGPUError(cudaMemcpy(rawTracklets0.data(),
-                             mTimeFrameGPU->getDeviceTrackletsVertexerOnly(iRof, 0),
-                             mTimeFrameGPU->getNClustersLayer(iRof, 1) * mVrtParams.maxTrackletsPerCluster * sizeof(o2::its::Tracklet),
-                             cudaMemcpyDeviceToHost),
-                  __FILE__, __LINE__);
-    checkGPUError(cudaMemcpy(rawTracklets1.data(),
-                             mTimeFrameGPU->getDeviceTrackletsVertexerOnly(iRof, 1),
-                             mTimeFrameGPU->getNClustersLayer(iRof, 1) * mVrtParams.maxTrackletsPerCluster * sizeof(o2::its::Tracklet),
-                             cudaMemcpyDeviceToHost),
-                  __FILE__, __LINE__);
-    for (int iCluster{0}; iCluster < mTimeFrameGPU->getNClustersLayer(iRof, 1); ++iCluster) {
-      for (int iTracklet{0}; iTracklet < NtrackletsClusters01[iRof][iCluster]; ++iTracklet) {
-        tracklets01.push_back(rawTracklets0[iCluster * mVrtParams.maxTrackletsPerCluster + iTracklet]);
-      }
-    }
-    for (int iCluster{0}; iCluster < mTimeFrameGPU->getNClustersLayer(iRof, 1); ++iCluster) {
-      for (int iTracklet{0}; iTracklet < NtrackletsClusters12[iRof][iCluster]; ++iTracklet) {
-        tracklets12.push_back(rawTracklets1[iCluster * mVrtParams.maxTrackletsPerCluster + iTracklet]);
-      }
-    }
-    tr_tre->Fill();
-  }
-  trackletFile->cd();
-  tr_tre->Write();
-  trackletFile->Close();
-#endif
+//     std::copy(NtrackletsClusters01[iRof].begin(), NtrackletsClusters01[iRof].end(), std::ostream_iterator<double>(out01, "\t"));
+//     std::copy(NtrackletsClusters12[iRof].begin(), NtrackletsClusters12[iRof].end(), std::ostream_iterator<double>(out12, "\t"));
+//     out01 << std::endl;
+//     out12 << std::endl;
+//   }
+//   out01.close();
+//   out12.close();
+//   // Dump lines on root file
+//   TFile* trackletFile = TFile::Open("artefacts_tf_gpu.root", "recreate");
+//   TTree* tr_tre = new TTree("tracklets", "tf");
+//   std::vector<o2::its::Tracklet> tracklets01;
+//   std::vector<o2::its::Tracklet> tracklets12;
+//   tr_tre->Branch("Tracklets0", &tracklets01);
+//   tr_tre->Branch("Tracklets1", &tracklets12);
+//   for (int iRof{0}; iRof < mTimeFrameGPU->getNrof(); ++iRof) {
+//     tracklets01.clear();
+//     tracklets12.clear();
+//     std::vector<o2::its::Tracklet> rawTracklets0(mTimeFrameGPU->getNClustersLayer(iRof, 1) * mVrtParams.maxTrackletsPerCluster);
+//     std::vector<o2::its::Tracklet> rawTracklets1(mTimeFrameGPU->getNClustersLayer(iRof, 1) * mVrtParams.maxTrackletsPerCluster);
+//     checkGPUError(cudaMemcpy(rawTracklets0.data(),
+//                              mTimeFrameGPU->getDeviceTrackletsVertexerOnly(iRof, 0),
+//                              mTimeFrameGPU->getNClustersLayer(iRof, 1) * mVrtParams.maxTrackletsPerCluster * sizeof(o2::its::Tracklet),
+//                              cudaMemcpyDeviceToHost),
+//                   __FILE__, __LINE__);
+//     checkGPUError(cudaMemcpy(rawTracklets1.data(),
+//                              mTimeFrameGPU->getDeviceTrackletsVertexerOnly(iRof, 1),
+//                              mTimeFrameGPU->getNClustersLayer(iRof, 1) * mVrtParams.maxTrackletsPerCluster * sizeof(o2::its::Tracklet),
+//                              cudaMemcpyDeviceToHost),
+//                   __FILE__, __LINE__);
+//     for (int iCluster{0}; iCluster < mTimeFrameGPU->getNClustersLayer(iRof, 1); ++iCluster) {
+//       for (int iTracklet{0}; iTracklet < NtrackletsClusters01[iRof][iCluster]; ++iTracklet) {
+//         tracklets01.push_back(rawTracklets0[iCluster * mVrtParams.maxTrackletsPerCluster + iTracklet]);
+//       }
+//     }
+//     for (int iCluster{0}; iCluster < mTimeFrameGPU->getNClustersLayer(iRof, 1); ++iCluster) {
+//       for (int iTracklet{0}; iTracklet < NtrackletsClusters12[iRof][iCluster]; ++iTracklet) {
+//         tracklets12.push_back(rawTracklets1[iCluster * mVrtParams.maxTrackletsPerCluster + iTracklet]);
+//       }
+//     }
+//     tr_tre->Fill();
+//   }
+//   trackletFile->cd();
+//   tr_tre->Write();
+//   trackletFile->Close();
+// #endif
 }
 
 void VertexerTraitsGPU::computeTrackletMatching()
 {
-  if (!mTimeFrameGPU->getClusters().size()) {
-    return;
-  }
-  for (int rofId{0}; rofId < mTimeFrameGPU->getNrof(); ++rofId) {
-    const dim3 threadsPerBlock{gpu::utils::host::getBlockSize(mTimeFrameGPU->getNClustersLayer(rofId, 1))};
-    const dim3 blocksGrid{gpu::utils::host::getBlocksGrid(threadsPerBlock, mTimeFrameGPU->getNClustersLayer(rofId, 1))};
+//   if (!mTimeFrameGPU->getClusters().size()) {
+//     return;
+//   }
+//   for (int rofId{0}; rofId < mTimeFrameGPU->getNrof(); ++rofId) {
+//     const dim3 threadsPerBlock{gpu::utils::host::getBlockSize(mTimeFrameGPU->getNClustersLayer(rofId, 1))};
+//     const dim3 blocksGrid{gpu::utils::host::getBlocksGrid(threadsPerBlock, mTimeFrameGPU->getNClustersLayer(rofId, 1))};
 
-    size_t bufferSize = mTimeFrameGPU->getConfig().tmpCUBBufferSize;
+//     size_t bufferSize = mTimeFrameGPU->getConfig().tmpCUBBufferSize;
 
-    // Reset used tracklets
-    checkGPUError(cudaMemset(mTimeFrameGPU->getDeviceUsedTracklets(rofId), false, sizeof(unsigned char) * mVrtParams.maxTrackletsPerCluster * mTimeFrameGPU->getNClustersLayer(rofId, 1)), __FILE__, __LINE__);
+//     // Reset used tracklets
+//     checkGPUError(cudaMemset(mTimeFrameGPU->getDeviceUsedTracklets(rofId), false, sizeof(unsigned char) * mVrtParams.maxTrackletsPerCluster * mTimeFrameGPU->getNClustersLayer(rofId, 1)), __FILE__, __LINE__);
 
-    gpu::trackletSelectionKernel<true><<<blocksGrid, threadsPerBlock>>>(
-      mTimeFrameGPU->getDeviceClustersOnLayer(rofId, 0),
-      mTimeFrameGPU->getDeviceClustersOnLayer(rofId, 1),
-      mTimeFrameGPU->getNClustersLayer(rofId, 1),
-      mTimeFrameGPU->getDeviceTrackletsVertexerOnly(rofId, 0),
-      mTimeFrameGPU->getDeviceTrackletsVertexerOnly(rofId, 1),
-      mTimeFrameGPU->getDeviceNTrackletsCluster(rofId, 0),
-      mTimeFrameGPU->getDeviceNTrackletsCluster(rofId, 1),
-      mTimeFrameGPU->getDeviceUsedTracklets(rofId),
-      mTimeFrameGPU->getDeviceLines(rofId),
-      mTimeFrameGPU->getDeviceNFoundLines(rofId),
-      mTimeFrameGPU->getDeviceExclusiveNFoundLines(rofId),
-      mVrtParams.maxTrackletsPerCluster,
-      mVrtParams.tanLambdaCut,
-      mVrtParams.phiCut);
+//     gpu::trackletSelectionKernel<true><<<blocksGrid, threadsPerBlock>>>(
+//       mTimeFrameGPU->getDeviceClustersOnLayer(rofId, 0),
+//       mTimeFrameGPU->getDeviceClustersOnLayer(rofId, 1),
+//       mTimeFrameGPU->getNClustersLayer(rofId, 1),
+//       mTimeFrameGPU->getDeviceTrackletsVertexerOnly(rofId, 0),
+//       mTimeFrameGPU->getDeviceTrackletsVertexerOnly(rofId, 1),
+//       mTimeFrameGPU->getDeviceNTrackletsCluster(rofId, 0),
+//       mTimeFrameGPU->getDeviceNTrackletsCluster(rofId, 1),
+//       mTimeFrameGPU->getDeviceUsedTracklets(rofId),
+//       mTimeFrameGPU->getDeviceLines(rofId),
+//       mTimeFrameGPU->getDeviceNFoundLines(rofId),
+//       mTimeFrameGPU->getDeviceExclusiveNFoundLines(rofId),
+//       mVrtParams.maxTrackletsPerCluster,
+//       mVrtParams.tanLambdaCut,
+//       mVrtParams.phiCut);
 
-    discardResult(cub::DeviceScan::ExclusiveSum(reinterpret_cast<void*>(mTimeFrameGPU->getDeviceCUBBuffer(rofId)),
-                                                bufferSize,
-                                                mTimeFrameGPU->getDeviceNFoundLines(rofId),
-                                                mTimeFrameGPU->getDeviceExclusiveNFoundLines(rofId),
-                                                mTimeFrameGPU->getNClustersLayer(rofId, 1)));
-    // Reset used tracklets
-    checkGPUError(cudaMemset(mTimeFrameGPU->getDeviceUsedTracklets(rofId), false, sizeof(unsigned char) * mVrtParams.maxTrackletsPerCluster * mTimeFrameGPU->getNClustersLayer(rofId, 1)), __FILE__, __LINE__);
+//     discardResult(cub::DeviceScan::ExclusiveSum(reinterpret_cast<void*>(mTimeFrameGPU->getDeviceCUBBuffer(rofId)),
+//                                                 bufferSize,
+//                                                 mTimeFrameGPU->getDeviceNFoundLines(rofId),
+//                                                 mTimeFrameGPU->getDeviceExclusiveNFoundLines(rofId),
+//                                                 mTimeFrameGPU->getNClustersLayer(rofId, 1)));
+//     // Reset used tracklets
+//     checkGPUError(cudaMemset(mTimeFrameGPU->getDeviceUsedTracklets(rofId), false, sizeof(unsigned char) * mVrtParams.maxTrackletsPerCluster * mTimeFrameGPU->getNClustersLayer(rofId, 1)), __FILE__, __LINE__);
 
-    gpu::trackletSelectionKernel<false><<<blocksGrid, threadsPerBlock>>>(
-      mTimeFrameGPU->getDeviceClustersOnLayer(rofId, 0),
-      mTimeFrameGPU->getDeviceClustersOnLayer(rofId, 1),
-      mTimeFrameGPU->getNClustersLayer(rofId, 1),
-      mTimeFrameGPU->getDeviceTrackletsVertexerOnly(rofId, 0),
-      mTimeFrameGPU->getDeviceTrackletsVertexerOnly(rofId, 1),
-      mTimeFrameGPU->getDeviceNTrackletsCluster(rofId, 0),
-      mTimeFrameGPU->getDeviceNTrackletsCluster(rofId, 1),
-      mTimeFrameGPU->getDeviceUsedTracklets(rofId),
-      mTimeFrameGPU->getDeviceLines(rofId),
-      mTimeFrameGPU->getDeviceNFoundLines(rofId),
-      mTimeFrameGPU->getDeviceExclusiveNFoundLines(rofId),
-      mVrtParams.maxTrackletsPerCluster,
-      mVrtParams.tanLambdaCut,
-      mVrtParams.phiCut);
-    gpuThrowOnError();
+//     gpu::trackletSelectionKernel<false><<<blocksGrid, threadsPerBlock>>>(
+//       mTimeFrameGPU->getDeviceClustersOnLayer(rofId, 0),
+//       mTimeFrameGPU->getDeviceClustersOnLayer(rofId, 1),
+//       mTimeFrameGPU->getNClustersLayer(rofId, 1),
+//       mTimeFrameGPU->getDeviceTrackletsVertexerOnly(rofId, 0),
+//       mTimeFrameGPU->getDeviceTrackletsVertexerOnly(rofId, 1),
+//       mTimeFrameGPU->getDeviceNTrackletsCluster(rofId, 0),
+//       mTimeFrameGPU->getDeviceNTrackletsCluster(rofId, 1),
+//       mTimeFrameGPU->getDeviceUsedTracklets(rofId),
+//       mTimeFrameGPU->getDeviceLines(rofId),
+//       mTimeFrameGPU->getDeviceNFoundLines(rofId),
+//       mTimeFrameGPU->getDeviceExclusiveNFoundLines(rofId),
+//       mVrtParams.maxTrackletsPerCluster,
+//       mVrtParams.tanLambdaCut,
+//       mVrtParams.phiCut);
+//     gpuThrowOnError();
 
-    // Code to be removed in case of GPU vertex computing
-    int excLas, nLas, nLines;
-    checkGPUError(cudaMemcpy(&excLas, mTimeFrameGPU->getDeviceExclusiveNFoundLines(rofId) + mTimeFrameGPU->getNClustersLayer(rofId, 1) - 1, sizeof(int), cudaMemcpyDeviceToHost), __FILE__, __LINE__);
-    checkGPUError(cudaMemcpy(&nLas, mTimeFrameGPU->getDeviceNFoundLines(rofId) + mTimeFrameGPU->getNClustersLayer(rofId, 1) - 1, sizeof(int), cudaMemcpyDeviceToHost), __FILE__, __LINE__);
-    nLines = excLas + nLas;
-    mTimeFrameGPU->getLines(rofId).resize(nLines);
-    checkGPUError(cudaMemcpy(mTimeFrameGPU->getLines(rofId).data(), mTimeFrameGPU->getDeviceLines(rofId), sizeof(Line) * nLines, cudaMemcpyDeviceToHost), __FILE__, __LINE__);
-  }
+//     // Code to be removed in case of GPU vertex computing
+//     int excLas, nLas, nLines;
+//     checkGPUError(cudaMemcpy(&excLas, mTimeFrameGPU->getDeviceExclusiveNFoundLines(rofId) + mTimeFrameGPU->getNClustersLayer(rofId, 1) - 1, sizeof(int), cudaMemcpyDeviceToHost), __FILE__, __LINE__);
+//     checkGPUError(cudaMemcpy(&nLas, mTimeFrameGPU->getDeviceNFoundLines(rofId) + mTimeFrameGPU->getNClustersLayer(rofId, 1) - 1, sizeof(int), cudaMemcpyDeviceToHost), __FILE__, __LINE__);
+//     nLines = excLas + nLas;
+//     mTimeFrameGPU->getLines(rofId).resize(nLines);
+//     checkGPUError(cudaMemcpy(mTimeFrameGPU->getLines(rofId).data(), mTimeFrameGPU->getDeviceLines(rofId), sizeof(Line) * nLines, cudaMemcpyDeviceToHost), __FILE__, __LINE__);
+//   }
 
-#ifdef VTX_DEBUG
-  discardResult(cudaDeviceSynchronize());
-  std::vector<std::vector<int>> NFoundLines(mTimeFrameGPU->getNrof()), ExcNFoundLines(mTimeFrameGPU->getNrof());
-  std::ofstream nlines_out("N_lines_gpu.txt");
-  for (size_t rofId{0}; rofId < mTimeFrameGPU->getNrof(); ++rofId) {
-    NFoundLines[rofId].resize(mTimeFrameGPU->getNClustersLayer(rofId, 1));
-    ExcNFoundLines[rofId].resize(mTimeFrameGPU->getNClustersLayer(rofId, 1));
-    checkGPUError(cudaMemcpy(NFoundLines[rofId].data(), mTimeFrameGPU->getDeviceNFoundLines(rofId), sizeof(int) * mTimeFrameGPU->getNClustersLayer(rofId, 1), cudaMemcpyDeviceToHost), __FILE__, __LINE__);
-    checkGPUError(cudaMemcpy(ExcNFoundLines[rofId].data(), mTimeFrameGPU->getDeviceExclusiveNFoundLines(rofId), sizeof(int) * mTimeFrameGPU->getNClustersLayer(rofId, 1), cudaMemcpyDeviceToHost), __FILE__, __LINE__);
-    std::copy(NFoundLines[rofId].begin(), NFoundLines[rofId].end(), std::ostream_iterator<double>(nlines_out, "\t"));
-    nlines_out << std::endl;
-    std::copy(ExcNFoundLines[rofId].begin(), ExcNFoundLines[rofId].end(), std::ostream_iterator<double>(nlines_out, "\t"));
-    nlines_out << std::endl
-               << " ---\n";
-  }
-  nlines_out.close();
+// #ifdef VTX_DEBUG
+//   discardResult(cudaDeviceSynchronize());
+//   std::vector<std::vector<int>> NFoundLines(mTimeFrameGPU->getNrof()), ExcNFoundLines(mTimeFrameGPU->getNrof());
+//   std::ofstream nlines_out("N_lines_gpu.txt");
+//   for (size_t rofId{0}; rofId < mTimeFrameGPU->getNrof(); ++rofId) {
+//     NFoundLines[rofId].resize(mTimeFrameGPU->getNClustersLayer(rofId, 1));
+//     ExcNFoundLines[rofId].resize(mTimeFrameGPU->getNClustersLayer(rofId, 1));
+//     checkGPUError(cudaMemcpy(NFoundLines[rofId].data(), mTimeFrameGPU->getDeviceNFoundLines(rofId), sizeof(int) * mTimeFrameGPU->getNClustersLayer(rofId, 1), cudaMemcpyDeviceToHost), __FILE__, __LINE__);
+//     checkGPUError(cudaMemcpy(ExcNFoundLines[rofId].data(), mTimeFrameGPU->getDeviceExclusiveNFoundLines(rofId), sizeof(int) * mTimeFrameGPU->getNClustersLayer(rofId, 1), cudaMemcpyDeviceToHost), __FILE__, __LINE__);
+//     std::copy(NFoundLines[rofId].begin(), NFoundLines[rofId].end(), std::ostream_iterator<double>(nlines_out, "\t"));
+//     nlines_out << std::endl;
+//     std::copy(ExcNFoundLines[rofId].begin(), ExcNFoundLines[rofId].end(), std::ostream_iterator<double>(nlines_out, "\t"));
+//     nlines_out << std::endl
+//                << " ---\n";
+//   }
+//   nlines_out.close();
 
-  // Dump lines on root file
-  TFile* trackletFile = TFile::Open("artefacts_tf_gpu.root", "update");
-  TTree* ln_tre = new TTree("lines", "tf");
-  std::vector<o2::its::Line> lines_vec(0);
-  ln_tre->Branch("Lines", &lines_vec);
-  for (int rofId{0}; rofId < mTimeFrameGPU->getNrof(); ++rofId) {
-    lines_vec.clear();
-    auto sum = std::accumulate(NFoundLines[rofId].begin(), NFoundLines[rofId].end(), 0);
-    lines_vec.resize(sum);
-    checkGPUError(cudaMemcpy(lines_vec.data(), mTimeFrameGPU->getDeviceLines(rofId), sizeof(Line) * sum, cudaMemcpyDeviceToHost), __FILE__, __LINE__);
-    ln_tre->Fill();
-  }
-  trackletFile->cd();
-  ln_tre->Write();
-  trackletFile->Close();
-#endif
+//   // Dump lines on root file
+//   TFile* trackletFile = TFile::Open("artefacts_tf_gpu.root", "update");
+//   TTree* ln_tre = new TTree("lines", "tf");
+//   std::vector<o2::its::Line> lines_vec(0);
+//   ln_tre->Branch("Lines", &lines_vec);
+//   for (int rofId{0}; rofId < mTimeFrameGPU->getNrof(); ++rofId) {
+//     lines_vec.clear();
+//     auto sum = std::accumulate(NFoundLines[rofId].begin(), NFoundLines[rofId].end(), 0);
+//     lines_vec.resize(sum);
+//     checkGPUError(cudaMemcpy(lines_vec.data(), mTimeFrameGPU->getDeviceLines(rofId), sizeof(Line) * sum, cudaMemcpyDeviceToHost), __FILE__, __LINE__);
+//     ln_tre->Fill();
+//   }
+//   trackletFile->cd();
+//   ln_tre->Write();
+//   trackletFile->Close();
+// #endif
 }
 
 void VertexerTraitsGPU::computeVertices()
 {
-#ifdef VTX_DEBUG
-  std::vector<std::vector<ClusterLines>> dbg_clusLines(mTimeFrameGPU->getNrof());
-#endif
-  std::vector<int> noClustersVec(mTimeFrameGPU->getNrof(), 0);
-  for (int rofId{0}; rofId < mTimeFrameGPU->getNrof(); ++rofId) {
-    const int numTracklets{static_cast<int>(mTimeFrameGPU->getLines(rofId).size())};
-    std::vector<bool> usedTracklets(numTracklets, false);
-    for (int tracklet1{0}; tracklet1 < numTracklets; ++tracklet1) {
-      if (usedTracklets[tracklet1]) {
-        continue;
-      }
-      for (int tracklet2{tracklet1 + 1}; tracklet2 < numTracklets; ++tracklet2) {
-        if (usedTracklets[tracklet2]) {
-          continue;
-        }
-        if (Line::getDCA(mTimeFrameGPU->getLines(rofId)[tracklet1], mTimeFrameGPU->getLines(rofId)[tracklet2]) < mVrtParams.pairCut) {
-          mTimeFrameGPU->getTrackletClusters(rofId).emplace_back(tracklet1, mTimeFrameGPU->getLines(rofId)[tracklet1], tracklet2, mTimeFrameGPU->getLines(rofId)[tracklet2]);
-          std::array<float, 3> tmpVertex{mTimeFrameGPU->getTrackletClusters(rofId).back().getVertex()};
-          if (tmpVertex[0] * tmpVertex[0] + tmpVertex[1] * tmpVertex[1] > 4.f) {
-            mTimeFrameGPU->getTrackletClusters(rofId).pop_back();
-            break;
-          }
-          usedTracklets[tracklet1] = true;
-          usedTracklets[tracklet2] = true;
-          for (int tracklet3{0}; tracklet3 < numTracklets; ++tracklet3) {
-            if (usedTracklets[tracklet3]) {
-              continue;
-            }
-            if (Line::getDistanceFromPoint(mTimeFrameGPU->getLines(rofId)[tracklet3], tmpVertex) < mVrtParams.pairCut) {
-              mTimeFrameGPU->getTrackletClusters(rofId).back().add(tracklet3, mTimeFrameGPU->getLines(rofId)[tracklet3]);
-              usedTracklets[tracklet3] = true;
-              tmpVertex = mTimeFrameGPU->getTrackletClusters(rofId).back().getVertex();
-            }
-          }
-          break;
-        }
-      }
-    }
-    std::sort(mTimeFrameGPU->getTrackletClusters(rofId).begin(), mTimeFrameGPU->getTrackletClusters(rofId).end(),
-              [](ClusterLines& cluster1, ClusterLines& cluster2) { return cluster1.getSize() > cluster2.getSize(); });
-    noClustersVec[rofId] = static_cast<int>(mTimeFrameGPU->getTrackletClusters(rofId).size());
-    for (int iCluster1{0}; iCluster1 < noClustersVec[rofId]; ++iCluster1) {
-      std::array<float, 3> vertex1{mTimeFrameGPU->getTrackletClusters(rofId)[iCluster1].getVertex()};
-      std::array<float, 3> vertex2{};
-      for (int iCluster2{iCluster1 + 1}; iCluster2 < noClustersVec[rofId]; ++iCluster2) {
-        vertex2 = mTimeFrameGPU->getTrackletClusters(rofId)[iCluster2].getVertex();
-        if (std::abs(vertex1[2] - vertex2[2]) < mVrtParams.clusterCut) {
-          float distance{(vertex1[0] - vertex2[0]) * (vertex1[0] - vertex2[0]) +
-                         (vertex1[1] - vertex2[1]) * (vertex1[1] - vertex2[1]) +
-                         (vertex1[2] - vertex2[2]) * (vertex1[2] - vertex2[2])};
-          if (distance < mVrtParams.pairCut * mVrtParams.pairCut) {
-            for (auto label : mTimeFrameGPU->getTrackletClusters(rofId)[iCluster2].getLabels()) {
-              mTimeFrameGPU->getTrackletClusters(rofId)[iCluster1].add(label, mTimeFrameGPU->getLines(rofId)[label]);
-              vertex1 = mTimeFrameGPU->getTrackletClusters(rofId)[iCluster1].getVertex();
-            }
-          }
-          mTimeFrameGPU->getTrackletClusters(rofId).erase(mTimeFrameGPU->getTrackletClusters(rofId).begin() + iCluster2);
-          --iCluster2;
-          --noClustersVec[rofId];
-        }
-      }
-    }
-  }
+// #ifdef VTX_DEBUG
+//   std::vector<std::vector<ClusterLines>> dbg_clusLines(mTimeFrameGPU->getNrof());
+// #endif
+//   std::vector<int> noClustersVec(mTimeFrameGPU->getNrof(), 0);
+//   for (int rofId{0}; rofId < mTimeFrameGPU->getNrof(); ++rofId) {
+//     const int numTracklets{static_cast<int>(mTimeFrameGPU->getLines(rofId).size())};
+//     std::vector<bool> usedTracklets(numTracklets, false);
+//     for (int tracklet1{0}; tracklet1 < numTracklets; ++tracklet1) {
+//       if (usedTracklets[tracklet1]) {
+//         continue;
+//       }
+//       for (int tracklet2{tracklet1 + 1}; tracklet2 < numTracklets; ++tracklet2) {
+//         if (usedTracklets[tracklet2]) {
+//           continue;
+//         }
+//         if (Line::getDCA(mTimeFrameGPU->getLines(rofId)[tracklet1], mTimeFrameGPU->getLines(rofId)[tracklet2]) < mVrtParams.pairCut) {
+//           mTimeFrameGPU->getTrackletClusters(rofId).emplace_back(tracklet1, mTimeFrameGPU->getLines(rofId)[tracklet1], tracklet2, mTimeFrameGPU->getLines(rofId)[tracklet2]);
+//           std::array<float, 3> tmpVertex{mTimeFrameGPU->getTrackletClusters(rofId).back().getVertex()};
+//           if (tmpVertex[0] * tmpVertex[0] + tmpVertex[1] * tmpVertex[1] > 4.f) {
+//             mTimeFrameGPU->getTrackletClusters(rofId).pop_back();
+//             break;
+//           }
+//           usedTracklets[tracklet1] = true;
+//           usedTracklets[tracklet2] = true;
+//           for (int tracklet3{0}; tracklet3 < numTracklets; ++tracklet3) {
+//             if (usedTracklets[tracklet3]) {
+//               continue;
+//             }
+//             if (Line::getDistanceFromPoint(mTimeFrameGPU->getLines(rofId)[tracklet3], tmpVertex) < mVrtParams.pairCut) {
+//               mTimeFrameGPU->getTrackletClusters(rofId).back().add(tracklet3, mTimeFrameGPU->getLines(rofId)[tracklet3]);
+//               usedTracklets[tracklet3] = true;
+//               tmpVertex = mTimeFrameGPU->getTrackletClusters(rofId).back().getVertex();
+//             }
+//           }
+//           break;
+//         }
+//       }
+//     }
+//     std::sort(mTimeFrameGPU->getTrackletClusters(rofId).begin(), mTimeFrameGPU->getTrackletClusters(rofId).end(),
+//               [](ClusterLines& cluster1, ClusterLines& cluster2) { return cluster1.getSize() > cluster2.getSize(); });
+//     noClustersVec[rofId] = static_cast<int>(mTimeFrameGPU->getTrackletClusters(rofId).size());
+//     for (int iCluster1{0}; iCluster1 < noClustersVec[rofId]; ++iCluster1) {
+//       std::array<float, 3> vertex1{mTimeFrameGPU->getTrackletClusters(rofId)[iCluster1].getVertex()};
+//       std::array<float, 3> vertex2{};
+//       for (int iCluster2{iCluster1 + 1}; iCluster2 < noClustersVec[rofId]; ++iCluster2) {
+//         vertex2 = mTimeFrameGPU->getTrackletClusters(rofId)[iCluster2].getVertex();
+//         if (std::abs(vertex1[2] - vertex2[2]) < mVrtParams.clusterCut) {
+//           float distance{(vertex1[0] - vertex2[0]) * (vertex1[0] - vertex2[0]) +
+//                          (vertex1[1] - vertex2[1]) * (vertex1[1] - vertex2[1]) +
+//                          (vertex1[2] - vertex2[2]) * (vertex1[2] - vertex2[2])};
+//           if (distance < mVrtParams.pairCut * mVrtParams.pairCut) {
+//             for (auto label : mTimeFrameGPU->getTrackletClusters(rofId)[iCluster2].getLabels()) {
+//               mTimeFrameGPU->getTrackletClusters(rofId)[iCluster1].add(label, mTimeFrameGPU->getLines(rofId)[label]);
+//               vertex1 = mTimeFrameGPU->getTrackletClusters(rofId)[iCluster1].getVertex();
+//             }
+//           }
+//           mTimeFrameGPU->getTrackletClusters(rofId).erase(mTimeFrameGPU->getTrackletClusters(rofId).begin() + iCluster2);
+//           --iCluster2;
+//           --noClustersVec[rofId];
+//         }
+//       }
+//     }
+//   }
 
-  for (int rofId{0}; rofId < mTimeFrameGPU->getNrof(); ++rofId) {
-#ifdef VTX_DEBUG
-    for (auto& cl : mTimeFrameGPU->getTrackletClusters(rofId)) {
-      dbg_clusLines[rofId].push_back(cl);
-    }
-#endif
-    for (int iCluster{0}; iCluster < noClustersVec[rofId]; ++iCluster) {
-      if (mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getSize() < mVrtParams.clusterContributorsCut && noClustersVec[rofId] > 1) {
-        mTimeFrameGPU->getTrackletClusters(rofId).erase(mTimeFrameGPU->getTrackletClusters(rofId).begin() + iCluster);
-        noClustersVec[rofId]--;
-        continue;
-      }
-      if (mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getVertex()[0] * mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getVertex()[0] +
-            mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getVertex()[1] * mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getVertex()[1] <
-          1.98 * 1.98) {
-        mVertices.emplace_back(mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getVertex()[0],
-                               mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getVertex()[1],
-                               mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getVertex()[2],
-                               mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getRMS2(),         // Symm matrix. Diagonal: RMS2 components,
-                                                                                                      // off-diagonal: square mean of projections on planes.
-                               mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getSize(),         // Contributors
-                               mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getAvgDistance2(), // In place of chi2
-                               rofId);
-      }
-    }
+//   for (int rofId{0}; rofId < mTimeFrameGPU->getNrof(); ++rofId) {
+// #ifdef VTX_DEBUG
+//     for (auto& cl : mTimeFrameGPU->getTrackletClusters(rofId)) {
+//       dbg_clusLines[rofId].push_back(cl);
+//     }
+// #endif
+//     for (int iCluster{0}; iCluster < noClustersVec[rofId]; ++iCluster) {
+//       if (mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getSize() < mVrtParams.clusterContributorsCut && noClustersVec[rofId] > 1) {
+//         mTimeFrameGPU->getTrackletClusters(rofId).erase(mTimeFrameGPU->getTrackletClusters(rofId).begin() + iCluster);
+//         noClustersVec[rofId]--;
+//         continue;
+//       }
+//       if (mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getVertex()[0] * mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getVertex()[0] +
+//             mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getVertex()[1] * mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getVertex()[1] <
+//           1.98 * 1.98) {
+//         mVertices.emplace_back(mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getVertex()[0],
+//                                mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getVertex()[1],
+//                                mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getVertex()[2],
+//                                mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getRMS2(),         // Symm matrix. Diagonal: RMS2 components,
+//                                                                                                       // off-diagonal: square mean of projections on planes.
+//                                mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getSize(),         // Contributors
+//                                mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getAvgDistance2(), // In place of chi2
+//                                rofId);
+//       }
+//     }
 
-    mTimeFrameGPU->addPrimaryVertices(mVertices);
-    mVertices.clear();
-  }
-#ifdef VTX_DEBUG
-  TFile* dbg_file = TFile::Open("artefacts_tf.root", "update");
-  TTree* ln_clus_lines_tree = new TTree("clusterlines", "tf");
-  std::vector<o2::its::ClusterLines> cl_lines_vec_pre(0);
-  std::vector<o2::its::ClusterLines> cl_lines_vec_post(0);
-  ln_clus_lines_tree->Branch("cllines_pre", &cl_lines_vec_pre);
-  ln_clus_lines_tree->Branch("cllines_post", &cl_lines_vec_post);
-  for (auto rofId{0}; rofId < mTimeFrameGPU->getNrof(); ++rofId) {
-    cl_lines_vec_pre.clear();
-    cl_lines_vec_post.clear();
-    for (auto& clln : mTimeFrameGPU->getTrackletClusters(rofId)) {
-      cl_lines_vec_post.push_back(clln);
-    }
-    for (auto& cl : dbg_clusLines[rofId]) {
-      cl_lines_vec_pre.push_back(cl);
-    }
-    ln_clus_lines_tree->Fill();
-  }
-  dbg_file->cd();
-  ln_clus_lines_tree->Write();
-  dbg_file->Close();
-#endif
+//     mTimeFrameGPU->addPrimaryVertices(mVertices);
+//     mVertices.clear();
+//   }
+// #ifdef VTX_DEBUG
+//   TFile* dbg_file = TFile::Open("artefacts_tf.root", "update");
+//   TTree* ln_clus_lines_tree = new TTree("clusterlines", "tf");
+//   std::vector<o2::its::ClusterLines> cl_lines_vec_pre(0);
+//   std::vector<o2::its::ClusterLines> cl_lines_vec_post(0);
+//   ln_clus_lines_tree->Branch("cllines_pre", &cl_lines_vec_pre);
+//   ln_clus_lines_tree->Branch("cllines_post", &cl_lines_vec_post);
+//   for (auto rofId{0}; rofId < mTimeFrameGPU->getNrof(); ++rofId) {
+//     cl_lines_vec_pre.clear();
+//     cl_lines_vec_post.clear();
+//     for (auto& clln : mTimeFrameGPU->getTrackletClusters(rofId)) {
+//       cl_lines_vec_post.push_back(clln);
+//     }
+//     for (auto& cl : dbg_clusLines[rofId]) {
+//       cl_lines_vec_pre.push_back(cl);
+//     }
+//     ln_clus_lines_tree->Fill();
+//   }
+//   dbg_file->cd();
+//   ln_clus_lines_tree->Write();
+//   dbg_file->Close();
+// #endif
 }
 
 void VertexerTraitsGPU::computeVerticesHist()
 {
-  if (!mTimeFrameGPU->getClusters().size()) {
-    return;
-  }
-  for (int rofId{0}; rofId < mTimeFrameGPU->getNrof(); ++rofId) {
-    const dim3 threadsPerBlock{gpu::utils::host::getBlockSize(mTimeFrameGPU->getNClustersLayer(rofId, 1))};
-    const dim3 blocksGrid{gpu::utils::host::getBlocksGrid(threadsPerBlock, mTimeFrameGPU->getNClustersLayer(rofId, 1))};
+  // if (!mTimeFrameGPU->getClusters().size()) {
+  //   return;
+  // }
+  // for (int rofId{0}; rofId < mTimeFrameGPU->getNrof(); ++rofId) {
+  //   const dim3 threadsPerBlock{gpu::utils::host::getBlockSize(mTimeFrameGPU->getNClustersLayer(rofId, 1))};
+  //   const dim3 blocksGrid{gpu::utils::host::getBlocksGrid(threadsPerBlock, mTimeFrameGPU->getNClustersLayer(rofId, 1))};
 
-    size_t bufferSize = mTimeFrameGPU->getConfig().tmpCUBBufferSize;
-    int excLas, nLas, nLines;
-    checkGPUError(cudaMemcpy(&excLas, mTimeFrameGPU->getDeviceExclusiveNFoundLines(rofId) + mTimeFrameGPU->getNClustersLayer(rofId, 1) - 1, sizeof(int), cudaMemcpyDeviceToHost), __FILE__, __LINE__);
-    checkGPUError(cudaMemcpy(&nLas, mTimeFrameGPU->getDeviceNFoundLines(rofId) + mTimeFrameGPU->getNClustersLayer(rofId, 1) - 1, sizeof(int), cudaMemcpyDeviceToHost), __FILE__, __LINE__);
-    nLines = excLas + nLas;
-    int nCentroids{nLines * (nLines - 1) / 2};
-    int* histogramXY[2] = {mTimeFrameGPU->getDeviceXHistograms(rofId), mTimeFrameGPU->getDeviceYHistograms(rofId)};
-    float tmpArrayLow[2] = {mTimeFrameGPU->getConfig().histConf.lowHistBoundariesXYZ[0], mTimeFrameGPU->getConfig().histConf.lowHistBoundariesXYZ[1]};
-    float tmpArrayHigh[2] = {mTimeFrameGPU->getConfig().histConf.highHistBoundariesXYZ[0], mTimeFrameGPU->getConfig().histConf.highHistBoundariesXYZ[1]};
+  //   size_t bufferSize = mTimeFrameGPU->getConfig().tmpCUBBufferSize;
+  //   int excLas, nLas, nLines;
+  //   checkGPUError(cudaMemcpy(&excLas, mTimeFrameGPU->getDeviceExclusiveNFoundLines(rofId) + mTimeFrameGPU->getNClustersLayer(rofId, 1) - 1, sizeof(int), cudaMemcpyDeviceToHost), __FILE__, __LINE__);
+  //   checkGPUError(cudaMemcpy(&nLas, mTimeFrameGPU->getDeviceNFoundLines(rofId) + mTimeFrameGPU->getNClustersLayer(rofId, 1) - 1, sizeof(int), cudaMemcpyDeviceToHost), __FILE__, __LINE__);
+  //   nLines = excLas + nLas;
+  //   int nCentroids{nLines * (nLines - 1) / 2};
+  //   int* histogramXY[2] = {mTimeFrameGPU->getDeviceXHistograms(rofId), mTimeFrameGPU->getDeviceYHistograms(rofId)};
+  //   float tmpArrayLow[2] = {mTimeFrameGPU->getConfig().histConf.lowHistBoundariesXYZ[0], mTimeFrameGPU->getConfig().histConf.lowHistBoundariesXYZ[1]};
+  //   float tmpArrayHigh[2] = {mTimeFrameGPU->getConfig().histConf.highHistBoundariesXYZ[0], mTimeFrameGPU->getConfig().histConf.highHistBoundariesXYZ[1]};
 
-    gpu::computeCentroidsKernel<<<blocksGrid, threadsPerBlock>>>(
-      mTimeFrameGPU->getDeviceLines(rofId),
-      mTimeFrameGPU->getDeviceNFoundLines(rofId),
-      mTimeFrameGPU->getDeviceExclusiveNFoundLines(rofId),
-      mTimeFrameGPU->getNClustersLayer(rofId, 1),
-      mTimeFrameGPU->getDeviceXYCentroids(rofId), // output
-      mTimeFrameGPU->getConfig().histConf.lowHistBoundariesXYZ[0],
-      mTimeFrameGPU->getConfig().histConf.highHistBoundariesXYZ[0],
-      mTimeFrameGPU->getConfig().histConf.lowHistBoundariesXYZ[1],
-      mTimeFrameGPU->getConfig().histConf.highHistBoundariesXYZ[1],
-      mVrtParams.histPairCut);
+  //   gpu::computeCentroidsKernel<<<blocksGrid, threadsPerBlock>>>(
+  //     mTimeFrameGPU->getDeviceLines(rofId),
+  //     mTimeFrameGPU->getDeviceNFoundLines(rofId),
+  //     mTimeFrameGPU->getDeviceExclusiveNFoundLines(rofId),
+  //     mTimeFrameGPU->getNClustersLayer(rofId, 1),
+  //     mTimeFrameGPU->getDeviceXYCentroids(rofId), // output
+  //     mTimeFrameGPU->getConfig().histConf.lowHistBoundariesXYZ[0],
+  //     mTimeFrameGPU->getConfig().histConf.highHistBoundariesXYZ[0],
+  //     mTimeFrameGPU->getConfig().histConf.lowHistBoundariesXYZ[1],
+  //     mTimeFrameGPU->getConfig().histConf.highHistBoundariesXYZ[1],
+  //     mVrtParams.histPairCut);
 
-    discardResult(cub::DeviceHistogram::MultiHistogramEven<2, 2>(reinterpret_cast<void*>(mTimeFrameGPU->getDeviceCUBBuffer(rofId)), // d_temp_storage
-                                                                 bufferSize,                                                        // temp_storage_bytes
-                                                                 mTimeFrameGPU->getDeviceXYCentroids(rofId),                        // d_samples
-                                                                 histogramXY,                                                       // d_histogram
-                                                                 mTimeFrameGPU->getConfig().histConf.nBinsXYZ,                      // num_levels
-                                                                 tmpArrayLow,                                                       // lower_level
-                                                                 tmpArrayHigh,                                                      // fupper_level
-                                                                 nCentroids));                                                      // num_row_pixels
+  //   discardResult(cub::DeviceHistogram::MultiHistogramEven<2, 2>(reinterpret_cast<void*>(mTimeFrameGPU->getDeviceCUBBuffer(rofId)), // d_temp_storage
+  //                                                                bufferSize,                                                        // temp_storage_bytes
+  //                                                                mTimeFrameGPU->getDeviceXYCentroids(rofId),                        // d_samples
+  //                                                                histogramXY,                                                       // d_histogram
+  //                                                                mTimeFrameGPU->getConfig().histConf.nBinsXYZ,                      // num_levels
+  //                                                                tmpArrayLow,                                                       // lower_level
+  //                                                                tmpArrayHigh,                                                      // fupper_level
+  //                                                                nCentroids));                                                      // num_row_pixels
 
-    discardResult(cub::DeviceReduce::ArgMax(reinterpret_cast<void*>(mTimeFrameGPU->getDeviceCUBBuffer(rofId)),
-                                            bufferSize,
-                                            histogramXY[0],
-                                            mTimeFrameGPU->getTmpVertexPositionBins(rofId),
-                                            mTimeFrameGPU->getConfig().histConf.nBinsXYZ[0]));
+  //   discardResult(cub::DeviceReduce::ArgMax(reinterpret_cast<void*>(mTimeFrameGPU->getDeviceCUBBuffer(rofId)),
+  //                                           bufferSize,
+  //                                           histogramXY[0],
+  //                                           mTimeFrameGPU->getTmpVertexPositionBins(rofId),
+  //                                           mTimeFrameGPU->getConfig().histConf.nBinsXYZ[0]));
 
-    discardResult(cub::DeviceReduce::ArgMax(reinterpret_cast<void*>(mTimeFrameGPU->getDeviceCUBBuffer(rofId)),
-                                            bufferSize,
-                                            histogramXY[1],
-                                            mTimeFrameGPU->getTmpVertexPositionBins(rofId) + 1,
-                                            mTimeFrameGPU->getConfig().histConf.nBinsXYZ[1]));
+  //   discardResult(cub::DeviceReduce::ArgMax(reinterpret_cast<void*>(mTimeFrameGPU->getDeviceCUBBuffer(rofId)),
+  //                                           bufferSize,
+  //                                           histogramXY[1],
+  //                                           mTimeFrameGPU->getTmpVertexPositionBins(rofId) + 1,
+  //                                           mTimeFrameGPU->getConfig().histConf.nBinsXYZ[1]));
 
-    gpu::computeZCentroidsKernel<<<blocksGrid, threadsPerBlock>>>(nLines,
-                                                                  mTimeFrameGPU->getTmpVertexPositionBins(rofId),
-                                                                  mTimeFrameGPU->getDeviceBeamPosition(rofId),
-                                                                  mTimeFrameGPU->getDeviceLines(rofId),
-                                                                  mTimeFrameGPU->getDeviceZCentroids(rofId), // output
-                                                                  mTimeFrameGPU->getDeviceXHistograms(rofId),
-                                                                  mTimeFrameGPU->getConfig().histConf.lowHistBoundariesXYZ[0],
-                                                                  mTimeFrameGPU->getConfig().histConf.binSizeHistX,
-                                                                  mTimeFrameGPU->getConfig().histConf.nBinsXYZ[0],
-                                                                  mTimeFrameGPU->getDeviceYHistograms(rofId),
-                                                                  mTimeFrameGPU->getConfig().histConf.lowHistBoundariesXYZ[1],
-                                                                  mTimeFrameGPU->getConfig().histConf.binSizeHistY,
-                                                                  mTimeFrameGPU->getConfig().histConf.nBinsXYZ[1],
-                                                                  mTimeFrameGPU->getConfig().histConf.lowHistBoundariesXYZ[2],
-                                                                  mVrtParams.histPairCut,
-                                                                  mTimeFrameGPU->getConfig().histConf.binSpanXYZ[0],
-                                                                  mTimeFrameGPU->getConfig().histConf.binSpanXYZ[1]);
+  //   gpu::computeZCentroidsKernel<<<blocksGrid, threadsPerBlock>>>(nLines,
+  //                                                                 mTimeFrameGPU->getTmpVertexPositionBins(rofId),
+  //                                                                 mTimeFrameGPU->getDeviceBeamPosition(rofId),
+  //                                                                 mTimeFrameGPU->getDeviceLines(rofId),
+  //                                                                 mTimeFrameGPU->getDeviceZCentroids(rofId), // output
+  //                                                                 mTimeFrameGPU->getDeviceXHistograms(rofId),
+  //                                                                 mTimeFrameGPU->getConfig().histConf.lowHistBoundariesXYZ[0],
+  //                                                                 mTimeFrameGPU->getConfig().histConf.binSizeHistX,
+  //                                                                 mTimeFrameGPU->getConfig().histConf.nBinsXYZ[0],
+  //                                                                 mTimeFrameGPU->getDeviceYHistograms(rofId),
+  //                                                                 mTimeFrameGPU->getConfig().histConf.lowHistBoundariesXYZ[1],
+  //                                                                 mTimeFrameGPU->getConfig().histConf.binSizeHistY,
+  //                                                                 mTimeFrameGPU->getConfig().histConf.nBinsXYZ[1],
+  //                                                                 mTimeFrameGPU->getConfig().histConf.lowHistBoundariesXYZ[2],
+  //                                                                 mVrtParams.histPairCut,
+  //                                                                 mTimeFrameGPU->getConfig().histConf.binSpanXYZ[0],
+  //                                                                 mTimeFrameGPU->getConfig().histConf.binSpanXYZ[1]);
 
-    discardResult(cub::DeviceHistogram::HistogramEven(reinterpret_cast<void*>(mTimeFrameGPU->getDeviceCUBBuffer(rofId)), // d_temp_storage
-                                                      bufferSize,                                                        // temp_storage_bytes
-                                                      mTimeFrameGPU->getDeviceZCentroids(rofId),                         // d_samples
-                                                      mTimeFrameGPU->getDeviceZHistograms(rofId),                        // d_histogram
-                                                      mTimeFrameGPU->getConfig().histConf.nBinsXYZ[2],                   // num_levels
-                                                      mTimeFrameGPU->getConfig().histConf.lowHistBoundariesXYZ[2],       // lower_level
-                                                      mTimeFrameGPU->getConfig().histConf.highHistBoundariesXYZ[2],      // fupper_level
-                                                      nLines));                                                          // num_row_pixels
+  //   discardResult(cub::DeviceHistogram::HistogramEven(reinterpret_cast<void*>(mTimeFrameGPU->getDeviceCUBBuffer(rofId)), // d_temp_storage
+  //                                                     bufferSize,                                                        // temp_storage_bytes
+  //                                                     mTimeFrameGPU->getDeviceZCentroids(rofId),                         // d_samples
+  //                                                     mTimeFrameGPU->getDeviceZHistograms(rofId),                        // d_histogram
+  //                                                     mTimeFrameGPU->getConfig().histConf.nBinsXYZ[2],                   // num_levels
+  //                                                     mTimeFrameGPU->getConfig().histConf.lowHistBoundariesXYZ[2],       // lower_level
+  //                                                     mTimeFrameGPU->getConfig().histConf.highHistBoundariesXYZ[2],      // fupper_level
+  //                                                     nLines));                                                          // num_row_pixels
 
-    for (int iVertex{0}; iVertex < mTimeFrameGPU->getConfig().maxVerticesCapacity; ++iVertex) {
-      discardResult(cub::DeviceReduce::ArgMax(reinterpret_cast<void*>(mTimeFrameGPU->getDeviceCUBBuffer(rofId)),
-                                              bufferSize,
-                                              mTimeFrameGPU->getDeviceZHistograms(rofId),
-                                              mTimeFrameGPU->getTmpVertexPositionBins(rofId) + 2,
-                                              mTimeFrameGPU->getConfig().histConf.nBinsXYZ[2]));
+  //   for (int iVertex{0}; iVertex < mTimeFrameGPU->getConfig().maxVerticesCapacity; ++iVertex) {
+  //     discardResult(cub::DeviceReduce::ArgMax(reinterpret_cast<void*>(mTimeFrameGPU->getDeviceCUBBuffer(rofId)),
+  //                                             bufferSize,
+  //                                             mTimeFrameGPU->getDeviceZHistograms(rofId),
+  //                                             mTimeFrameGPU->getTmpVertexPositionBins(rofId) + 2,
+  //                                             mTimeFrameGPU->getConfig().histConf.nBinsXYZ[2]));
 
-      gpu::computeVertexKernel<<<blocksGrid, 5>>>(mTimeFrameGPU->getTmpVertexPositionBins(rofId),
-                                                  mTimeFrameGPU->getDeviceZHistograms(rofId),
-                                                  mTimeFrameGPU->getConfig().histConf.lowHistBoundariesXYZ[2],
-                                                  mTimeFrameGPU->getConfig().histConf.binSizeHistZ,
-                                                  mTimeFrameGPU->getConfig().histConf.nBinsXYZ[2],
-                                                  mTimeFrameGPU->getDeviceVertices(rofId),
-                                                  mTimeFrameGPU->getDeviceBeamPosition(rofId),
-                                                  iVertex,
-                                                  mVrtParams.clusterContributorsCut,
-                                                  mTimeFrameGPU->getConfig().histConf.binSpanXYZ[2]);
-    }
-    std::vector<Vertex> GPUvertices;
-    GPUvertices.resize(mTimeFrameGPU->getConfig().maxVerticesCapacity);
-    checkGPUError(cudaMemcpy(GPUvertices.data(), mTimeFrameGPU->getDeviceVertices(rofId), sizeof(gpu::GPUVertex) * mTimeFrameGPU->getConfig().maxVerticesCapacity, cudaMemcpyDeviceToHost), __FILE__, __LINE__);
-    int nRealVertices{0};
-    for (auto& vertex : GPUvertices) {
-      if (vertex.getX() || vertex.getY() || vertex.getZ()) {
-        ++nRealVertices;
-      }
-    }
-    mTimeFrameGPU->addPrimaryVertices(gsl::span<const Vertex>{GPUvertices.data(), static_cast<gsl::span<const Vertex>::size_type>(nRealVertices)});
-  }
-  gpuThrowOnError();
+  //     gpu::computeVertexKernel<<<blocksGrid, 5>>>(mTimeFrameGPU->getTmpVertexPositionBins(rofId),
+  //                                                 mTimeFrameGPU->getDeviceZHistograms(rofId),
+  //                                                 mTimeFrameGPU->getConfig().histConf.lowHistBoundariesXYZ[2],
+  //                                                 mTimeFrameGPU->getConfig().histConf.binSizeHistZ,
+  //                                                 mTimeFrameGPU->getConfig().histConf.nBinsXYZ[2],
+  //                                                 mTimeFrameGPU->getDeviceVertices(rofId),
+  //                                                 mTimeFrameGPU->getDeviceBeamPosition(rofId),
+  //                                                 iVertex,
+  //                                                 mVrtParams.clusterContributorsCut,
+  //                                                 mTimeFrameGPU->getConfig().histConf.binSpanXYZ[2]);
+  //   }
+  //   std::vector<Vertex> GPUvertices;
+  //   GPUvertices.resize(mTimeFrameGPU->getConfig().maxVerticesCapacity);
+  //   checkGPUError(cudaMemcpy(GPUvertices.data(), mTimeFrameGPU->getDeviceVertices(rofId), sizeof(gpu::GPUVertex) * mTimeFrameGPU->getConfig().maxVerticesCapacity, cudaMemcpyDeviceToHost), __FILE__, __LINE__);
+  //   int nRealVertices{0};
+  //   for (auto& vertex : GPUvertices) {
+  //     if (vertex.getX() || vertex.getY() || vertex.getZ()) {
+  //       ++nRealVertices;
+  //     }
+  //   }
+  //   mTimeFrameGPU->addPrimaryVertices(gsl::span<const Vertex>{GPUvertices.data(), static_cast<gsl::span<const Vertex>::size_type>(nRealVertices)});
+  // }
+  // gpuThrowOnError();
 }
 
 VertexerTraits* createVertexerTraitsGPU()

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
@@ -412,7 +412,9 @@ void VertexerTraitsGPU::computeTracklets()
   if (!mTimeFrameGPU->getClusters().size()) {
     return;
   }
-  mTimeFrameGPU->loadBatch<gpu::Task::Vertexer>();
+  for (size_t part{0}; part < mTimeFrameGPU->getNPartions(); ++part) {
+    mTimeFrameGPU->loadPartitionData<gpu::Task::Vertexer>(part);
+  }
   // for (int rofId{0}; rofId < mTimeFrameGPU->getNrof(); ++rofId) {
   //     const dim3 threadsPerBlock{gpu::utils::getBlockSize(mTimeFrameGPU->getNClustersLayer(rofId, 1))};
   //     const dim3 blocksGrid{gpu::utils::getBlocksGrid(threadsPerBlock, mTimeFrameGPU->getNClustersLayer(rofId, 1))};

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
@@ -409,319 +409,320 @@ void VertexerTraitsGPU::updateVertexingParameters(const VertexingParameters& vrt
 
 void VertexerTraitsGPU::computeTracklets()
 {
-//   if (!mTimeFrameGPU->getClusters().size()) {
-//     return;
-//   }
-//   for (int rofId{0}; rofId < mTimeFrameGPU->getNrof(); ++rofId) {
-//     const dim3 threadsPerBlock{gpu::utils::host::getBlockSize(mTimeFrameGPU->getNClustersLayer(rofId, 1))};
-//     const dim3 blocksGrid{gpu::utils::host::getBlocksGrid(threadsPerBlock, mTimeFrameGPU->getNClustersLayer(rofId, 1))};
-//     gpu::trackleterKernel<TrackletMode::Layer0Layer1><<<blocksGrid, threadsPerBlock, 0, mTimeFrameGPU->getStream(0).get()>>>(
-//       mTimeFrameGPU->getDeviceClustersOnLayer(rofId, 0),
-//       mTimeFrameGPU->getDeviceClustersOnLayer(rofId, 1),
-//       mTimeFrameGPU->getNClustersLayer(rofId, 0),
-//       mTimeFrameGPU->getNClustersLayer(rofId, 1),
-//       mTimeFrameGPU->getDeviceIndexTableAtRof(0, rofId),
-//       mVrtParams.phiCut,
-//       mTimeFrameGPU->getDeviceTrackletsVertexerOnly(rofId, 0),
-//       mTimeFrameGPU->getDeviceNTrackletsCluster(rofId, 0),
-//       mDeviceIndexTableUtils,
-//       rofId,
-//       mVrtParams.maxTrackletsPerCluster);
-//     gpu::trackleterKernel<TrackletMode::Layer1Layer2><<<blocksGrid, threadsPerBlock, 0, mTimeFrameGPU->getStream(1).get()>>>(
-//       mTimeFrameGPU->getDeviceClustersOnLayer(rofId, 2),
-//       mTimeFrameGPU->getDeviceClustersOnLayer(rofId, 1),
-//       mTimeFrameGPU->getNClustersLayer(rofId, 2),
-//       mTimeFrameGPU->getNClustersLayer(rofId, 1),
-//       mTimeFrameGPU->getDeviceIndexTableAtRof(2, rofId),
-//       mVrtParams.phiCut,
-//       mTimeFrameGPU->getDeviceTrackletsVertexerOnly(rofId, 1),
-//       mTimeFrameGPU->getDeviceNTrackletsCluster(rofId, 1),
-//       mDeviceIndexTableUtils,
-//       rofId,
-//       mVrtParams.maxTrackletsPerCluster);
-//   }
-// #ifdef VTX_DEBUG
-//   discardResult(cudaDeviceSynchronize());
-//   std::ofstream out01("NTC01.txt"), out12("NTC12.txt");
-//   std::vector<std::vector<int>> NtrackletsClusters01(mTimeFrameGPU->getNrof());
-//   std::vector<std::vector<int>> NtrackletsClusters12(mTimeFrameGPU->getNrof());
-//   for (int iRof{0}; iRof < mTimeFrameGPU->getNrof(); ++iRof) {
-//     NtrackletsClusters01[iRof].resize(mTimeFrameGPU->getNClustersLayer(iRof, 1));
-//     NtrackletsClusters12[iRof].resize(mTimeFrameGPU->getNClustersLayer(iRof, 1));
-//     checkGPUError(cudaMemcpy(NtrackletsClusters01[iRof].data(),
-//                              mTimeFrameGPU->getDeviceNTrackletsCluster(iRof, 0),
-//                              sizeof(int) * mTimeFrameGPU->getNClustersLayer(iRof, 1),
-//                              cudaMemcpyDeviceToHost),
-//                   __FILE__, __LINE__);
-//     checkGPUError(cudaMemcpy(NtrackletsClusters12[iRof].data(),
-//                              mTimeFrameGPU->getDeviceNTrackletsCluster(iRof, 1),
-//                              sizeof(int) * mTimeFrameGPU->getNClustersLayer(iRof, 1),
-//                              cudaMemcpyDeviceToHost),
-//                   __FILE__, __LINE__);
+  if (!mTimeFrameGPU->getClusters().size()) {
+    return;
+  }
+  mTimeFrameGPU->loadBatch<gpu::Task::Vertexer>(nullptr);
+  // for (int rofId{0}; rofId < mTimeFrameGPU->getNrof(); ++rofId) {
+  //     const dim3 threadsPerBlock{gpu::utils::host::getBlockSize(mTimeFrameGPU->getNClustersLayer(rofId, 1))};
+  //     const dim3 blocksGrid{gpu::utils::host::getBlocksGrid(threadsPerBlock, mTimeFrameGPU->getNClustersLayer(rofId, 1))};
+  //     gpu::trackleterKernel<TrackletMode::Layer0Layer1><<<blocksGrid, threadsPerBlock, 0, mTimeFrameGPU->getStream(0).get()>>>(
+  //       mTimeFrameGPU->getDeviceClustersOnLayer(rofId, 0),
+  //       mTimeFrameGPU->getDeviceClustersOnLayer(rofId, 1),
+  //       mTimeFrameGPU->getNClustersLayer(rofId, 0),
+  //       mTimeFrameGPU->getNClustersLayer(rofId, 1),
+  //       mTimeFrameGPU->getDeviceIndexTableAtRof(0, rofId),
+  //       mVrtParams.phiCut,
+  //       mTimeFrameGPU->getDeviceTrackletsVertexerOnly(rofId, 0),
+  //       mTimeFrameGPU->getDeviceNTrackletsCluster(rofId, 0),
+  //       mDeviceIndexTableUtils,
+  //       rofId,
+  //       mVrtParams.maxTrackletsPerCluster);
+  //     gpu::trackleterKernel<TrackletMode::Layer1Layer2><<<blocksGrid, threadsPerBlock, 0, mTimeFrameGPU->getStream(1).get()>>>(
+  //       mTimeFrameGPU->getDeviceClustersOnLayer(rofId, 2),
+  //       mTimeFrameGPU->getDeviceClustersOnLayer(rofId, 1),
+  //       mTimeFrameGPU->getNClustersLayer(rofId, 2),
+  //       mTimeFrameGPU->getNClustersLayer(rofId, 1),
+  //       mTimeFrameGPU->getDeviceIndexTableAtRof(2, rofId),
+  //       mVrtParams.phiCut,
+  //       mTimeFrameGPU->getDeviceTrackletsVertexerOnly(rofId, 1),
+  //       mTimeFrameGPU->getDeviceNTrackletsCluster(rofId, 1),
+  //       mDeviceIndexTableUtils,
+  //       rofId,
+  //       mVrtParams.maxTrackletsPerCluster);
+  // }
+  // #ifdef VTX_DEBUG
+  //   discardResult(cudaDeviceSynchronize());
+  //   std::ofstream out01("NTC01.txt"), out12("NTC12.txt");
+  //   std::vector<std::vector<int>> NtrackletsClusters01(mTimeFrameGPU->getNrof());
+  //   std::vector<std::vector<int>> NtrackletsClusters12(mTimeFrameGPU->getNrof());
+  //   for (int iRof{0}; iRof < mTimeFrameGPU->getNrof(); ++iRof) {
+  //     NtrackletsClusters01[iRof].resize(mTimeFrameGPU->getNClustersLayer(iRof, 1));
+  //     NtrackletsClusters12[iRof].resize(mTimeFrameGPU->getNClustersLayer(iRof, 1));
+  //     checkGPUError(cudaMemcpy(NtrackletsClusters01[iRof].data(),
+  //                              mTimeFrameGPU->getDeviceNTrackletsCluster(iRof, 0),
+  //                              sizeof(int) * mTimeFrameGPU->getNClustersLayer(iRof, 1),
+  //                              cudaMemcpyDeviceToHost),
+  //                   __FILE__, __LINE__);
+  //     checkGPUError(cudaMemcpy(NtrackletsClusters12[iRof].data(),
+  //                              mTimeFrameGPU->getDeviceNTrackletsCluster(iRof, 1),
+  //                              sizeof(int) * mTimeFrameGPU->getNClustersLayer(iRof, 1),
+  //                              cudaMemcpyDeviceToHost),
+  //                   __FILE__, __LINE__);
 
-//     std::copy(NtrackletsClusters01[iRof].begin(), NtrackletsClusters01[iRof].end(), std::ostream_iterator<double>(out01, "\t"));
-//     std::copy(NtrackletsClusters12[iRof].begin(), NtrackletsClusters12[iRof].end(), std::ostream_iterator<double>(out12, "\t"));
-//     out01 << std::endl;
-//     out12 << std::endl;
-//   }
-//   out01.close();
-//   out12.close();
-//   // Dump lines on root file
-//   TFile* trackletFile = TFile::Open("artefacts_tf_gpu.root", "recreate");
-//   TTree* tr_tre = new TTree("tracklets", "tf");
-//   std::vector<o2::its::Tracklet> tracklets01;
-//   std::vector<o2::its::Tracklet> tracklets12;
-//   tr_tre->Branch("Tracklets0", &tracklets01);
-//   tr_tre->Branch("Tracklets1", &tracklets12);
-//   for (int iRof{0}; iRof < mTimeFrameGPU->getNrof(); ++iRof) {
-//     tracklets01.clear();
-//     tracklets12.clear();
-//     std::vector<o2::its::Tracklet> rawTracklets0(mTimeFrameGPU->getNClustersLayer(iRof, 1) * mVrtParams.maxTrackletsPerCluster);
-//     std::vector<o2::its::Tracklet> rawTracklets1(mTimeFrameGPU->getNClustersLayer(iRof, 1) * mVrtParams.maxTrackletsPerCluster);
-//     checkGPUError(cudaMemcpy(rawTracklets0.data(),
-//                              mTimeFrameGPU->getDeviceTrackletsVertexerOnly(iRof, 0),
-//                              mTimeFrameGPU->getNClustersLayer(iRof, 1) * mVrtParams.maxTrackletsPerCluster * sizeof(o2::its::Tracklet),
-//                              cudaMemcpyDeviceToHost),
-//                   __FILE__, __LINE__);
-//     checkGPUError(cudaMemcpy(rawTracklets1.data(),
-//                              mTimeFrameGPU->getDeviceTrackletsVertexerOnly(iRof, 1),
-//                              mTimeFrameGPU->getNClustersLayer(iRof, 1) * mVrtParams.maxTrackletsPerCluster * sizeof(o2::its::Tracklet),
-//                              cudaMemcpyDeviceToHost),
-//                   __FILE__, __LINE__);
-//     for (int iCluster{0}; iCluster < mTimeFrameGPU->getNClustersLayer(iRof, 1); ++iCluster) {
-//       for (int iTracklet{0}; iTracklet < NtrackletsClusters01[iRof][iCluster]; ++iTracklet) {
-//         tracklets01.push_back(rawTracklets0[iCluster * mVrtParams.maxTrackletsPerCluster + iTracklet]);
-//       }
-//     }
-//     for (int iCluster{0}; iCluster < mTimeFrameGPU->getNClustersLayer(iRof, 1); ++iCluster) {
-//       for (int iTracklet{0}; iTracklet < NtrackletsClusters12[iRof][iCluster]; ++iTracklet) {
-//         tracklets12.push_back(rawTracklets1[iCluster * mVrtParams.maxTrackletsPerCluster + iTracklet]);
-//       }
-//     }
-//     tr_tre->Fill();
-//   }
-//   trackletFile->cd();
-//   tr_tre->Write();
-//   trackletFile->Close();
-// #endif
+  //     std::copy(NtrackletsClusters01[iRof].begin(), NtrackletsClusters01[iRof].end(), std::ostream_iterator<double>(out01, "\t"));
+  //     std::copy(NtrackletsClusters12[iRof].begin(), NtrackletsClusters12[iRof].end(), std::ostream_iterator<double>(out12, "\t"));
+  //     out01 << std::endl;
+  //     out12 << std::endl;
+  //   }
+  //   out01.close();
+  //   out12.close();
+  //   // Dump lines on root file
+  //   TFile* trackletFile = TFile::Open("artefacts_tf_gpu.root", "recreate");
+  //   TTree* tr_tre = new TTree("tracklets", "tf");
+  //   std::vector<o2::its::Tracklet> tracklets01;
+  //   std::vector<o2::its::Tracklet> tracklets12;
+  //   tr_tre->Branch("Tracklets0", &tracklets01);
+  //   tr_tre->Branch("Tracklets1", &tracklets12);
+  //   for (int iRof{0}; iRof < mTimeFrameGPU->getNrof(); ++iRof) {
+  //     tracklets01.clear();
+  //     tracklets12.clear();
+  //     std::vector<o2::its::Tracklet> rawTracklets0(mTimeFrameGPU->getNClustersLayer(iRof, 1) * mVrtParams.maxTrackletsPerCluster);
+  //     std::vector<o2::its::Tracklet> rawTracklets1(mTimeFrameGPU->getNClustersLayer(iRof, 1) * mVrtParams.maxTrackletsPerCluster);
+  //     checkGPUError(cudaMemcpy(rawTracklets0.data(),
+  //                              mTimeFrameGPU->getDeviceTrackletsVertexerOnly(iRof, 0),
+  //                              mTimeFrameGPU->getNClustersLayer(iRof, 1) * mVrtParams.maxTrackletsPerCluster * sizeof(o2::its::Tracklet),
+  //                              cudaMemcpyDeviceToHost),
+  //                   __FILE__, __LINE__);
+  //     checkGPUError(cudaMemcpy(rawTracklets1.data(),
+  //                              mTimeFrameGPU->getDeviceTrackletsVertexerOnly(iRof, 1),
+  //                              mTimeFrameGPU->getNClustersLayer(iRof, 1) * mVrtParams.maxTrackletsPerCluster * sizeof(o2::its::Tracklet),
+  //                              cudaMemcpyDeviceToHost),
+  //                   __FILE__, __LINE__);
+  //     for (int iCluster{0}; iCluster < mTimeFrameGPU->getNClustersLayer(iRof, 1); ++iCluster) {
+  //       for (int iTracklet{0}; iTracklet < NtrackletsClusters01[iRof][iCluster]; ++iTracklet) {
+  //         tracklets01.push_back(rawTracklets0[iCluster * mVrtParams.maxTrackletsPerCluster + iTracklet]);
+  //       }
+  //     }
+  //     for (int iCluster{0}; iCluster < mTimeFrameGPU->getNClustersLayer(iRof, 1); ++iCluster) {
+  //       for (int iTracklet{0}; iTracklet < NtrackletsClusters12[iRof][iCluster]; ++iTracklet) {
+  //         tracklets12.push_back(rawTracklets1[iCluster * mVrtParams.maxTrackletsPerCluster + iTracklet]);
+  //       }
+  //     }
+  //     tr_tre->Fill();
+  //   }
+  //   trackletFile->cd();
+  //   tr_tre->Write();
+  //   trackletFile->Close();
+  // #endif
 }
 
 void VertexerTraitsGPU::computeTrackletMatching()
 {
-//   if (!mTimeFrameGPU->getClusters().size()) {
-//     return;
-//   }
-//   for (int rofId{0}; rofId < mTimeFrameGPU->getNrof(); ++rofId) {
-//     const dim3 threadsPerBlock{gpu::utils::host::getBlockSize(mTimeFrameGPU->getNClustersLayer(rofId, 1))};
-//     const dim3 blocksGrid{gpu::utils::host::getBlocksGrid(threadsPerBlock, mTimeFrameGPU->getNClustersLayer(rofId, 1))};
+  //   if (!mTimeFrameGPU->getClusters().size()) {
+  //     return;
+  //   }
+  //   for (int rofId{0}; rofId < mTimeFrameGPU->getNrof(); ++rofId) {
+  //     const dim3 threadsPerBlock{gpu::utils::host::getBlockSize(mTimeFrameGPU->getNClustersLayer(rofId, 1))};
+  //     const dim3 blocksGrid{gpu::utils::host::getBlocksGrid(threadsPerBlock, mTimeFrameGPU->getNClustersLayer(rofId, 1))};
 
-//     size_t bufferSize = mTimeFrameGPU->getConfig().tmpCUBBufferSize;
+  //     size_t bufferSize = mTimeFrameGPU->getConfig().tmpCUBBufferSize;
 
-//     // Reset used tracklets
-//     checkGPUError(cudaMemset(mTimeFrameGPU->getDeviceUsedTracklets(rofId), false, sizeof(unsigned char) * mVrtParams.maxTrackletsPerCluster * mTimeFrameGPU->getNClustersLayer(rofId, 1)), __FILE__, __LINE__);
+  //     // Reset used tracklets
+  //     checkGPUError(cudaMemset(mTimeFrameGPU->getDeviceUsedTracklets(rofId), false, sizeof(unsigned char) * mVrtParams.maxTrackletsPerCluster * mTimeFrameGPU->getNClustersLayer(rofId, 1)), __FILE__, __LINE__);
 
-//     gpu::trackletSelectionKernel<true><<<blocksGrid, threadsPerBlock>>>(
-//       mTimeFrameGPU->getDeviceClustersOnLayer(rofId, 0),
-//       mTimeFrameGPU->getDeviceClustersOnLayer(rofId, 1),
-//       mTimeFrameGPU->getNClustersLayer(rofId, 1),
-//       mTimeFrameGPU->getDeviceTrackletsVertexerOnly(rofId, 0),
-//       mTimeFrameGPU->getDeviceTrackletsVertexerOnly(rofId, 1),
-//       mTimeFrameGPU->getDeviceNTrackletsCluster(rofId, 0),
-//       mTimeFrameGPU->getDeviceNTrackletsCluster(rofId, 1),
-//       mTimeFrameGPU->getDeviceUsedTracklets(rofId),
-//       mTimeFrameGPU->getDeviceLines(rofId),
-//       mTimeFrameGPU->getDeviceNFoundLines(rofId),
-//       mTimeFrameGPU->getDeviceExclusiveNFoundLines(rofId),
-//       mVrtParams.maxTrackletsPerCluster,
-//       mVrtParams.tanLambdaCut,
-//       mVrtParams.phiCut);
+  //     gpu::trackletSelectionKernel<true><<<blocksGrid, threadsPerBlock>>>(
+  //       mTimeFrameGPU->getDeviceClustersOnLayer(rofId, 0),
+  //       mTimeFrameGPU->getDeviceClustersOnLayer(rofId, 1),
+  //       mTimeFrameGPU->getNClustersLayer(rofId, 1),
+  //       mTimeFrameGPU->getDeviceTrackletsVertexerOnly(rofId, 0),
+  //       mTimeFrameGPU->getDeviceTrackletsVertexerOnly(rofId, 1),
+  //       mTimeFrameGPU->getDeviceNTrackletsCluster(rofId, 0),
+  //       mTimeFrameGPU->getDeviceNTrackletsCluster(rofId, 1),
+  //       mTimeFrameGPU->getDeviceUsedTracklets(rofId),
+  //       mTimeFrameGPU->getDeviceLines(rofId),
+  //       mTimeFrameGPU->getDeviceNFoundLines(rofId),
+  //       mTimeFrameGPU->getDeviceExclusiveNFoundLines(rofId),
+  //       mVrtParams.maxTrackletsPerCluster,
+  //       mVrtParams.tanLambdaCut,
+  //       mVrtParams.phiCut);
 
-//     discardResult(cub::DeviceScan::ExclusiveSum(reinterpret_cast<void*>(mTimeFrameGPU->getDeviceCUBBuffer(rofId)),
-//                                                 bufferSize,
-//                                                 mTimeFrameGPU->getDeviceNFoundLines(rofId),
-//                                                 mTimeFrameGPU->getDeviceExclusiveNFoundLines(rofId),
-//                                                 mTimeFrameGPU->getNClustersLayer(rofId, 1)));
-//     // Reset used tracklets
-//     checkGPUError(cudaMemset(mTimeFrameGPU->getDeviceUsedTracklets(rofId), false, sizeof(unsigned char) * mVrtParams.maxTrackletsPerCluster * mTimeFrameGPU->getNClustersLayer(rofId, 1)), __FILE__, __LINE__);
+  //     discardResult(cub::DeviceScan::ExclusiveSum(reinterpret_cast<void*>(mTimeFrameGPU->getDeviceCUBBuffer(rofId)),
+  //                                                 bufferSize,
+  //                                                 mTimeFrameGPU->getDeviceNFoundLines(rofId),
+  //                                                 mTimeFrameGPU->getDeviceExclusiveNFoundLines(rofId),
+  //                                                 mTimeFrameGPU->getNClustersLayer(rofId, 1)));
+  //     // Reset used tracklets
+  //     checkGPUError(cudaMemset(mTimeFrameGPU->getDeviceUsedTracklets(rofId), false, sizeof(unsigned char) * mVrtParams.maxTrackletsPerCluster * mTimeFrameGPU->getNClustersLayer(rofId, 1)), __FILE__, __LINE__);
 
-//     gpu::trackletSelectionKernel<false><<<blocksGrid, threadsPerBlock>>>(
-//       mTimeFrameGPU->getDeviceClustersOnLayer(rofId, 0),
-//       mTimeFrameGPU->getDeviceClustersOnLayer(rofId, 1),
-//       mTimeFrameGPU->getNClustersLayer(rofId, 1),
-//       mTimeFrameGPU->getDeviceTrackletsVertexerOnly(rofId, 0),
-//       mTimeFrameGPU->getDeviceTrackletsVertexerOnly(rofId, 1),
-//       mTimeFrameGPU->getDeviceNTrackletsCluster(rofId, 0),
-//       mTimeFrameGPU->getDeviceNTrackletsCluster(rofId, 1),
-//       mTimeFrameGPU->getDeviceUsedTracklets(rofId),
-//       mTimeFrameGPU->getDeviceLines(rofId),
-//       mTimeFrameGPU->getDeviceNFoundLines(rofId),
-//       mTimeFrameGPU->getDeviceExclusiveNFoundLines(rofId),
-//       mVrtParams.maxTrackletsPerCluster,
-//       mVrtParams.tanLambdaCut,
-//       mVrtParams.phiCut);
-//     gpuThrowOnError();
+  //     gpu::trackletSelectionKernel<false><<<blocksGrid, threadsPerBlock>>>(
+  //       mTimeFrameGPU->getDeviceClustersOnLayer(rofId, 0),
+  //       mTimeFrameGPU->getDeviceClustersOnLayer(rofId, 1),
+  //       mTimeFrameGPU->getNClustersLayer(rofId, 1),
+  //       mTimeFrameGPU->getDeviceTrackletsVertexerOnly(rofId, 0),
+  //       mTimeFrameGPU->getDeviceTrackletsVertexerOnly(rofId, 1),
+  //       mTimeFrameGPU->getDeviceNTrackletsCluster(rofId, 0),
+  //       mTimeFrameGPU->getDeviceNTrackletsCluster(rofId, 1),
+  //       mTimeFrameGPU->getDeviceUsedTracklets(rofId),
+  //       mTimeFrameGPU->getDeviceLines(rofId),
+  //       mTimeFrameGPU->getDeviceNFoundLines(rofId),
+  //       mTimeFrameGPU->getDeviceExclusiveNFoundLines(rofId),
+  //       mVrtParams.maxTrackletsPerCluster,
+  //       mVrtParams.tanLambdaCut,
+  //       mVrtParams.phiCut);
+  //     gpuThrowOnError();
 
-//     // Code to be removed in case of GPU vertex computing
-//     int excLas, nLas, nLines;
-//     checkGPUError(cudaMemcpy(&excLas, mTimeFrameGPU->getDeviceExclusiveNFoundLines(rofId) + mTimeFrameGPU->getNClustersLayer(rofId, 1) - 1, sizeof(int), cudaMemcpyDeviceToHost), __FILE__, __LINE__);
-//     checkGPUError(cudaMemcpy(&nLas, mTimeFrameGPU->getDeviceNFoundLines(rofId) + mTimeFrameGPU->getNClustersLayer(rofId, 1) - 1, sizeof(int), cudaMemcpyDeviceToHost), __FILE__, __LINE__);
-//     nLines = excLas + nLas;
-//     mTimeFrameGPU->getLines(rofId).resize(nLines);
-//     checkGPUError(cudaMemcpy(mTimeFrameGPU->getLines(rofId).data(), mTimeFrameGPU->getDeviceLines(rofId), sizeof(Line) * nLines, cudaMemcpyDeviceToHost), __FILE__, __LINE__);
-//   }
+  //     // Code to be removed in case of GPU vertex computing
+  //     int excLas, nLas, nLines;
+  //     checkGPUError(cudaMemcpy(&excLas, mTimeFrameGPU->getDeviceExclusiveNFoundLines(rofId) + mTimeFrameGPU->getNClustersLayer(rofId, 1) - 1, sizeof(int), cudaMemcpyDeviceToHost), __FILE__, __LINE__);
+  //     checkGPUError(cudaMemcpy(&nLas, mTimeFrameGPU->getDeviceNFoundLines(rofId) + mTimeFrameGPU->getNClustersLayer(rofId, 1) - 1, sizeof(int), cudaMemcpyDeviceToHost), __FILE__, __LINE__);
+  //     nLines = excLas + nLas;
+  //     mTimeFrameGPU->getLines(rofId).resize(nLines);
+  //     checkGPUError(cudaMemcpy(mTimeFrameGPU->getLines(rofId).data(), mTimeFrameGPU->getDeviceLines(rofId), sizeof(Line) * nLines, cudaMemcpyDeviceToHost), __FILE__, __LINE__);
+  //   }
 
-// #ifdef VTX_DEBUG
-//   discardResult(cudaDeviceSynchronize());
-//   std::vector<std::vector<int>> NFoundLines(mTimeFrameGPU->getNrof()), ExcNFoundLines(mTimeFrameGPU->getNrof());
-//   std::ofstream nlines_out("N_lines_gpu.txt");
-//   for (size_t rofId{0}; rofId < mTimeFrameGPU->getNrof(); ++rofId) {
-//     NFoundLines[rofId].resize(mTimeFrameGPU->getNClustersLayer(rofId, 1));
-//     ExcNFoundLines[rofId].resize(mTimeFrameGPU->getNClustersLayer(rofId, 1));
-//     checkGPUError(cudaMemcpy(NFoundLines[rofId].data(), mTimeFrameGPU->getDeviceNFoundLines(rofId), sizeof(int) * mTimeFrameGPU->getNClustersLayer(rofId, 1), cudaMemcpyDeviceToHost), __FILE__, __LINE__);
-//     checkGPUError(cudaMemcpy(ExcNFoundLines[rofId].data(), mTimeFrameGPU->getDeviceExclusiveNFoundLines(rofId), sizeof(int) * mTimeFrameGPU->getNClustersLayer(rofId, 1), cudaMemcpyDeviceToHost), __FILE__, __LINE__);
-//     std::copy(NFoundLines[rofId].begin(), NFoundLines[rofId].end(), std::ostream_iterator<double>(nlines_out, "\t"));
-//     nlines_out << std::endl;
-//     std::copy(ExcNFoundLines[rofId].begin(), ExcNFoundLines[rofId].end(), std::ostream_iterator<double>(nlines_out, "\t"));
-//     nlines_out << std::endl
-//                << " ---\n";
-//   }
-//   nlines_out.close();
+  // #ifdef VTX_DEBUG
+  //   discardResult(cudaDeviceSynchronize());
+  //   std::vector<std::vector<int>> NFoundLines(mTimeFrameGPU->getNrof()), ExcNFoundLines(mTimeFrameGPU->getNrof());
+  //   std::ofstream nlines_out("N_lines_gpu.txt");
+  //   for (size_t rofId{0}; rofId < mTimeFrameGPU->getNrof(); ++rofId) {
+  //     NFoundLines[rofId].resize(mTimeFrameGPU->getNClustersLayer(rofId, 1));
+  //     ExcNFoundLines[rofId].resize(mTimeFrameGPU->getNClustersLayer(rofId, 1));
+  //     checkGPUError(cudaMemcpy(NFoundLines[rofId].data(), mTimeFrameGPU->getDeviceNFoundLines(rofId), sizeof(int) * mTimeFrameGPU->getNClustersLayer(rofId, 1), cudaMemcpyDeviceToHost), __FILE__, __LINE__);
+  //     checkGPUError(cudaMemcpy(ExcNFoundLines[rofId].data(), mTimeFrameGPU->getDeviceExclusiveNFoundLines(rofId), sizeof(int) * mTimeFrameGPU->getNClustersLayer(rofId, 1), cudaMemcpyDeviceToHost), __FILE__, __LINE__);
+  //     std::copy(NFoundLines[rofId].begin(), NFoundLines[rofId].end(), std::ostream_iterator<double>(nlines_out, "\t"));
+  //     nlines_out << std::endl;
+  //     std::copy(ExcNFoundLines[rofId].begin(), ExcNFoundLines[rofId].end(), std::ostream_iterator<double>(nlines_out, "\t"));
+  //     nlines_out << std::endl
+  //                << " ---\n";
+  //   }
+  //   nlines_out.close();
 
-//   // Dump lines on root file
-//   TFile* trackletFile = TFile::Open("artefacts_tf_gpu.root", "update");
-//   TTree* ln_tre = new TTree("lines", "tf");
-//   std::vector<o2::its::Line> lines_vec(0);
-//   ln_tre->Branch("Lines", &lines_vec);
-//   for (int rofId{0}; rofId < mTimeFrameGPU->getNrof(); ++rofId) {
-//     lines_vec.clear();
-//     auto sum = std::accumulate(NFoundLines[rofId].begin(), NFoundLines[rofId].end(), 0);
-//     lines_vec.resize(sum);
-//     checkGPUError(cudaMemcpy(lines_vec.data(), mTimeFrameGPU->getDeviceLines(rofId), sizeof(Line) * sum, cudaMemcpyDeviceToHost), __FILE__, __LINE__);
-//     ln_tre->Fill();
-//   }
-//   trackletFile->cd();
-//   ln_tre->Write();
-//   trackletFile->Close();
-// #endif
+  //   // Dump lines on root file
+  //   TFile* trackletFile = TFile::Open("artefacts_tf_gpu.root", "update");
+  //   TTree* ln_tre = new TTree("lines", "tf");
+  //   std::vector<o2::its::Line> lines_vec(0);
+  //   ln_tre->Branch("Lines", &lines_vec);
+  //   for (int rofId{0}; rofId < mTimeFrameGPU->getNrof(); ++rofId) {
+  //     lines_vec.clear();
+  //     auto sum = std::accumulate(NFoundLines[rofId].begin(), NFoundLines[rofId].end(), 0);
+  //     lines_vec.resize(sum);
+  //     checkGPUError(cudaMemcpy(lines_vec.data(), mTimeFrameGPU->getDeviceLines(rofId), sizeof(Line) * sum, cudaMemcpyDeviceToHost), __FILE__, __LINE__);
+  //     ln_tre->Fill();
+  //   }
+  //   trackletFile->cd();
+  //   ln_tre->Write();
+  //   trackletFile->Close();
+  // #endif
 }
 
 void VertexerTraitsGPU::computeVertices()
 {
-// #ifdef VTX_DEBUG
-//   std::vector<std::vector<ClusterLines>> dbg_clusLines(mTimeFrameGPU->getNrof());
-// #endif
-//   std::vector<int> noClustersVec(mTimeFrameGPU->getNrof(), 0);
-//   for (int rofId{0}; rofId < mTimeFrameGPU->getNrof(); ++rofId) {
-//     const int numTracklets{static_cast<int>(mTimeFrameGPU->getLines(rofId).size())};
-//     std::vector<bool> usedTracklets(numTracklets, false);
-//     for (int tracklet1{0}; tracklet1 < numTracklets; ++tracklet1) {
-//       if (usedTracklets[tracklet1]) {
-//         continue;
-//       }
-//       for (int tracklet2{tracklet1 + 1}; tracklet2 < numTracklets; ++tracklet2) {
-//         if (usedTracklets[tracklet2]) {
-//           continue;
-//         }
-//         if (Line::getDCA(mTimeFrameGPU->getLines(rofId)[tracklet1], mTimeFrameGPU->getLines(rofId)[tracklet2]) < mVrtParams.pairCut) {
-//           mTimeFrameGPU->getTrackletClusters(rofId).emplace_back(tracklet1, mTimeFrameGPU->getLines(rofId)[tracklet1], tracklet2, mTimeFrameGPU->getLines(rofId)[tracklet2]);
-//           std::array<float, 3> tmpVertex{mTimeFrameGPU->getTrackletClusters(rofId).back().getVertex()};
-//           if (tmpVertex[0] * tmpVertex[0] + tmpVertex[1] * tmpVertex[1] > 4.f) {
-//             mTimeFrameGPU->getTrackletClusters(rofId).pop_back();
-//             break;
-//           }
-//           usedTracklets[tracklet1] = true;
-//           usedTracklets[tracklet2] = true;
-//           for (int tracklet3{0}; tracklet3 < numTracklets; ++tracklet3) {
-//             if (usedTracklets[tracklet3]) {
-//               continue;
-//             }
-//             if (Line::getDistanceFromPoint(mTimeFrameGPU->getLines(rofId)[tracklet3], tmpVertex) < mVrtParams.pairCut) {
-//               mTimeFrameGPU->getTrackletClusters(rofId).back().add(tracklet3, mTimeFrameGPU->getLines(rofId)[tracklet3]);
-//               usedTracklets[tracklet3] = true;
-//               tmpVertex = mTimeFrameGPU->getTrackletClusters(rofId).back().getVertex();
-//             }
-//           }
-//           break;
-//         }
-//       }
-//     }
-//     std::sort(mTimeFrameGPU->getTrackletClusters(rofId).begin(), mTimeFrameGPU->getTrackletClusters(rofId).end(),
-//               [](ClusterLines& cluster1, ClusterLines& cluster2) { return cluster1.getSize() > cluster2.getSize(); });
-//     noClustersVec[rofId] = static_cast<int>(mTimeFrameGPU->getTrackletClusters(rofId).size());
-//     for (int iCluster1{0}; iCluster1 < noClustersVec[rofId]; ++iCluster1) {
-//       std::array<float, 3> vertex1{mTimeFrameGPU->getTrackletClusters(rofId)[iCluster1].getVertex()};
-//       std::array<float, 3> vertex2{};
-//       for (int iCluster2{iCluster1 + 1}; iCluster2 < noClustersVec[rofId]; ++iCluster2) {
-//         vertex2 = mTimeFrameGPU->getTrackletClusters(rofId)[iCluster2].getVertex();
-//         if (std::abs(vertex1[2] - vertex2[2]) < mVrtParams.clusterCut) {
-//           float distance{(vertex1[0] - vertex2[0]) * (vertex1[0] - vertex2[0]) +
-//                          (vertex1[1] - vertex2[1]) * (vertex1[1] - vertex2[1]) +
-//                          (vertex1[2] - vertex2[2]) * (vertex1[2] - vertex2[2])};
-//           if (distance < mVrtParams.pairCut * mVrtParams.pairCut) {
-//             for (auto label : mTimeFrameGPU->getTrackletClusters(rofId)[iCluster2].getLabels()) {
-//               mTimeFrameGPU->getTrackletClusters(rofId)[iCluster1].add(label, mTimeFrameGPU->getLines(rofId)[label]);
-//               vertex1 = mTimeFrameGPU->getTrackletClusters(rofId)[iCluster1].getVertex();
-//             }
-//           }
-//           mTimeFrameGPU->getTrackletClusters(rofId).erase(mTimeFrameGPU->getTrackletClusters(rofId).begin() + iCluster2);
-//           --iCluster2;
-//           --noClustersVec[rofId];
-//         }
-//       }
-//     }
-//   }
+  // #ifdef VTX_DEBUG
+  //   std::vector<std::vector<ClusterLines>> dbg_clusLines(mTimeFrameGPU->getNrof());
+  // #endif
+  //   std::vector<int> noClustersVec(mTimeFrameGPU->getNrof(), 0);
+  //   for (int rofId{0}; rofId < mTimeFrameGPU->getNrof(); ++rofId) {
+  //     const int numTracklets{static_cast<int>(mTimeFrameGPU->getLines(rofId).size())};
+  //     std::vector<bool> usedTracklets(numTracklets, false);
+  //     for (int tracklet1{0}; tracklet1 < numTracklets; ++tracklet1) {
+  //       if (usedTracklets[tracklet1]) {
+  //         continue;
+  //       }
+  //       for (int tracklet2{tracklet1 + 1}; tracklet2 < numTracklets; ++tracklet2) {
+  //         if (usedTracklets[tracklet2]) {
+  //           continue;
+  //         }
+  //         if (Line::getDCA(mTimeFrameGPU->getLines(rofId)[tracklet1], mTimeFrameGPU->getLines(rofId)[tracklet2]) < mVrtParams.pairCut) {
+  //           mTimeFrameGPU->getTrackletClusters(rofId).emplace_back(tracklet1, mTimeFrameGPU->getLines(rofId)[tracklet1], tracklet2, mTimeFrameGPU->getLines(rofId)[tracklet2]);
+  //           std::array<float, 3> tmpVertex{mTimeFrameGPU->getTrackletClusters(rofId).back().getVertex()};
+  //           if (tmpVertex[0] * tmpVertex[0] + tmpVertex[1] * tmpVertex[1] > 4.f) {
+  //             mTimeFrameGPU->getTrackletClusters(rofId).pop_back();
+  //             break;
+  //           }
+  //           usedTracklets[tracklet1] = true;
+  //           usedTracklets[tracklet2] = true;
+  //           for (int tracklet3{0}; tracklet3 < numTracklets; ++tracklet3) {
+  //             if (usedTracklets[tracklet3]) {
+  //               continue;
+  //             }
+  //             if (Line::getDistanceFromPoint(mTimeFrameGPU->getLines(rofId)[tracklet3], tmpVertex) < mVrtParams.pairCut) {
+  //               mTimeFrameGPU->getTrackletClusters(rofId).back().add(tracklet3, mTimeFrameGPU->getLines(rofId)[tracklet3]);
+  //               usedTracklets[tracklet3] = true;
+  //               tmpVertex = mTimeFrameGPU->getTrackletClusters(rofId).back().getVertex();
+  //             }
+  //           }
+  //           break;
+  //         }
+  //       }
+  //     }
+  //     std::sort(mTimeFrameGPU->getTrackletClusters(rofId).begin(), mTimeFrameGPU->getTrackletClusters(rofId).end(),
+  //               [](ClusterLines& cluster1, ClusterLines& cluster2) { return cluster1.getSize() > cluster2.getSize(); });
+  //     noClustersVec[rofId] = static_cast<int>(mTimeFrameGPU->getTrackletClusters(rofId).size());
+  //     for (int iCluster1{0}; iCluster1 < noClustersVec[rofId]; ++iCluster1) {
+  //       std::array<float, 3> vertex1{mTimeFrameGPU->getTrackletClusters(rofId)[iCluster1].getVertex()};
+  //       std::array<float, 3> vertex2{};
+  //       for (int iCluster2{iCluster1 + 1}; iCluster2 < noClustersVec[rofId]; ++iCluster2) {
+  //         vertex2 = mTimeFrameGPU->getTrackletClusters(rofId)[iCluster2].getVertex();
+  //         if (std::abs(vertex1[2] - vertex2[2]) < mVrtParams.clusterCut) {
+  //           float distance{(vertex1[0] - vertex2[0]) * (vertex1[0] - vertex2[0]) +
+  //                          (vertex1[1] - vertex2[1]) * (vertex1[1] - vertex2[1]) +
+  //                          (vertex1[2] - vertex2[2]) * (vertex1[2] - vertex2[2])};
+  //           if (distance < mVrtParams.pairCut * mVrtParams.pairCut) {
+  //             for (auto label : mTimeFrameGPU->getTrackletClusters(rofId)[iCluster2].getLabels()) {
+  //               mTimeFrameGPU->getTrackletClusters(rofId)[iCluster1].add(label, mTimeFrameGPU->getLines(rofId)[label]);
+  //               vertex1 = mTimeFrameGPU->getTrackletClusters(rofId)[iCluster1].getVertex();
+  //             }
+  //           }
+  //           mTimeFrameGPU->getTrackletClusters(rofId).erase(mTimeFrameGPU->getTrackletClusters(rofId).begin() + iCluster2);
+  //           --iCluster2;
+  //           --noClustersVec[rofId];
+  //         }
+  //       }
+  //     }
+  //   }
 
-//   for (int rofId{0}; rofId < mTimeFrameGPU->getNrof(); ++rofId) {
-// #ifdef VTX_DEBUG
-//     for (auto& cl : mTimeFrameGPU->getTrackletClusters(rofId)) {
-//       dbg_clusLines[rofId].push_back(cl);
-//     }
-// #endif
-//     for (int iCluster{0}; iCluster < noClustersVec[rofId]; ++iCluster) {
-//       if (mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getSize() < mVrtParams.clusterContributorsCut && noClustersVec[rofId] > 1) {
-//         mTimeFrameGPU->getTrackletClusters(rofId).erase(mTimeFrameGPU->getTrackletClusters(rofId).begin() + iCluster);
-//         noClustersVec[rofId]--;
-//         continue;
-//       }
-//       if (mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getVertex()[0] * mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getVertex()[0] +
-//             mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getVertex()[1] * mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getVertex()[1] <
-//           1.98 * 1.98) {
-//         mVertices.emplace_back(mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getVertex()[0],
-//                                mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getVertex()[1],
-//                                mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getVertex()[2],
-//                                mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getRMS2(),         // Symm matrix. Diagonal: RMS2 components,
-//                                                                                                       // off-diagonal: square mean of projections on planes.
-//                                mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getSize(),         // Contributors
-//                                mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getAvgDistance2(), // In place of chi2
-//                                rofId);
-//       }
-//     }
+  //   for (int rofId{0}; rofId < mTimeFrameGPU->getNrof(); ++rofId) {
+  // #ifdef VTX_DEBUG
+  //     for (auto& cl : mTimeFrameGPU->getTrackletClusters(rofId)) {
+  //       dbg_clusLines[rofId].push_back(cl);
+  //     }
+  // #endif
+  //     for (int iCluster{0}; iCluster < noClustersVec[rofId]; ++iCluster) {
+  //       if (mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getSize() < mVrtParams.clusterContributorsCut && noClustersVec[rofId] > 1) {
+  //         mTimeFrameGPU->getTrackletClusters(rofId).erase(mTimeFrameGPU->getTrackletClusters(rofId).begin() + iCluster);
+  //         noClustersVec[rofId]--;
+  //         continue;
+  //       }
+  //       if (mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getVertex()[0] * mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getVertex()[0] +
+  //             mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getVertex()[1] * mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getVertex()[1] <
+  //           1.98 * 1.98) {
+  //         mVertices.emplace_back(mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getVertex()[0],
+  //                                mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getVertex()[1],
+  //                                mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getVertex()[2],
+  //                                mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getRMS2(),         // Symm matrix. Diagonal: RMS2 components,
+  //                                                                                                       // off-diagonal: square mean of projections on planes.
+  //                                mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getSize(),         // Contributors
+  //                                mTimeFrameGPU->getTrackletClusters(rofId)[iCluster].getAvgDistance2(), // In place of chi2
+  //                                rofId);
+  //       }
+  //     }
 
-//     mTimeFrameGPU->addPrimaryVertices(mVertices);
-//     mVertices.clear();
-//   }
-// #ifdef VTX_DEBUG
-//   TFile* dbg_file = TFile::Open("artefacts_tf.root", "update");
-//   TTree* ln_clus_lines_tree = new TTree("clusterlines", "tf");
-//   std::vector<o2::its::ClusterLines> cl_lines_vec_pre(0);
-//   std::vector<o2::its::ClusterLines> cl_lines_vec_post(0);
-//   ln_clus_lines_tree->Branch("cllines_pre", &cl_lines_vec_pre);
-//   ln_clus_lines_tree->Branch("cllines_post", &cl_lines_vec_post);
-//   for (auto rofId{0}; rofId < mTimeFrameGPU->getNrof(); ++rofId) {
-//     cl_lines_vec_pre.clear();
-//     cl_lines_vec_post.clear();
-//     for (auto& clln : mTimeFrameGPU->getTrackletClusters(rofId)) {
-//       cl_lines_vec_post.push_back(clln);
-//     }
-//     for (auto& cl : dbg_clusLines[rofId]) {
-//       cl_lines_vec_pre.push_back(cl);
-//     }
-//     ln_clus_lines_tree->Fill();
-//   }
-//   dbg_file->cd();
-//   ln_clus_lines_tree->Write();
-//   dbg_file->Close();
-// #endif
+  //     mTimeFrameGPU->addPrimaryVertices(mVertices);
+  //     mVertices.clear();
+  //   }
+  // #ifdef VTX_DEBUG
+  //   TFile* dbg_file = TFile::Open("artefacts_tf.root", "update");
+  //   TTree* ln_clus_lines_tree = new TTree("clusterlines", "tf");
+  //   std::vector<o2::its::ClusterLines> cl_lines_vec_pre(0);
+  //   std::vector<o2::its::ClusterLines> cl_lines_vec_post(0);
+  //   ln_clus_lines_tree->Branch("cllines_pre", &cl_lines_vec_pre);
+  //   ln_clus_lines_tree->Branch("cllines_post", &cl_lines_vec_post);
+  //   for (auto rofId{0}; rofId < mTimeFrameGPU->getNrof(); ++rofId) {
+  //     cl_lines_vec_pre.clear();
+  //     cl_lines_vec_post.clear();
+  //     for (auto& clln : mTimeFrameGPU->getTrackletClusters(rofId)) {
+  //       cl_lines_vec_post.push_back(clln);
+  //     }
+  //     for (auto& cl : dbg_clusLines[rofId]) {
+  //       cl_lines_vec_pre.push_back(cl);
+  //     }
+  //     ln_clus_lines_tree->Fill();
+  //   }
+  //   dbg_file->cd();
+  //   ln_clus_lines_tree->Write();
+  //   dbg_file->Close();
+  // #endif
 }
 
 void VertexerTraitsGPU::computeVerticesHist()

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
@@ -45,7 +45,7 @@ namespace its
 {
 using constants::its::VertexerHistogramVolume;
 using constants::math::TwoPi;
-using gpu::utils::host::checkGPUError;
+using gpu::utils::checkGPUError;
 using math_utils::getNormalizedPhi;
 
 using namespace constants::its2;
@@ -87,7 +87,7 @@ VertexerTraitsGPU::VertexerTraitsGPU()
 
 VertexerTraitsGPU::~VertexerTraitsGPU()
 {
-  gpu::utils::host::gpuFree(mDeviceIndexTableUtils);
+  gpu::utils::gpuFree(mDeviceIndexTableUtils);
 }
 
 void VertexerTraitsGPU::initialise(const TrackingParameters& trackingParams)
@@ -414,8 +414,8 @@ void VertexerTraitsGPU::computeTracklets()
   }
   mTimeFrameGPU->loadBatch<gpu::Task::Vertexer>();
   // for (int rofId{0}; rofId < mTimeFrameGPU->getNrof(); ++rofId) {
-  //     const dim3 threadsPerBlock{gpu::utils::host::getBlockSize(mTimeFrameGPU->getNClustersLayer(rofId, 1))};
-  //     const dim3 blocksGrid{gpu::utils::host::getBlocksGrid(threadsPerBlock, mTimeFrameGPU->getNClustersLayer(rofId, 1))};
+  //     const dim3 threadsPerBlock{gpu::utils::getBlockSize(mTimeFrameGPU->getNClustersLayer(rofId, 1))};
+  //     const dim3 blocksGrid{gpu::utils::getBlocksGrid(threadsPerBlock, mTimeFrameGPU->getNClustersLayer(rofId, 1))};
   //     gpu::trackleterKernel<TrackletMode::Layer0Layer1><<<blocksGrid, threadsPerBlock, 0, mTimeFrameGPU->getStream(0).get()>>>(
   //       mTimeFrameGPU->getDeviceClustersOnLayer(rofId, 0),
   //       mTimeFrameGPU->getDeviceClustersOnLayer(rofId, 1),
@@ -513,8 +513,8 @@ void VertexerTraitsGPU::computeTrackletMatching()
   //     return;
   //   }
   //   for (int rofId{0}; rofId < mTimeFrameGPU->getNrof(); ++rofId) {
-  //     const dim3 threadsPerBlock{gpu::utils::host::getBlockSize(mTimeFrameGPU->getNClustersLayer(rofId, 1))};
-  //     const dim3 blocksGrid{gpu::utils::host::getBlocksGrid(threadsPerBlock, mTimeFrameGPU->getNClustersLayer(rofId, 1))};
+  //     const dim3 threadsPerBlock{gpu::utils::getBlockSize(mTimeFrameGPU->getNClustersLayer(rofId, 1))};
+  //     const dim3 blocksGrid{gpu::utils::getBlocksGrid(threadsPerBlock, mTimeFrameGPU->getNClustersLayer(rofId, 1))};
 
   //     size_t bufferSize = mTimeFrameGPU->getConfig().tmpCUBBufferSize;
 
@@ -731,8 +731,8 @@ void VertexerTraitsGPU::computeVerticesHist()
   //   return;
   // }
   // for (int rofId{0}; rofId < mTimeFrameGPU->getNrof(); ++rofId) {
-  //   const dim3 threadsPerBlock{gpu::utils::host::getBlockSize(mTimeFrameGPU->getNClustersLayer(rofId, 1))};
-  //   const dim3 blocksGrid{gpu::utils::host::getBlocksGrid(threadsPerBlock, mTimeFrameGPU->getNClustersLayer(rofId, 1))};
+  //   const dim3 threadsPerBlock{gpu::utils::getBlockSize(mTimeFrameGPU->getNClustersLayer(rofId, 1))};
+  //   const dim3 blocksGrid{gpu::utils::getBlocksGrid(threadsPerBlock, mTimeFrameGPU->getNClustersLayer(rofId, 1))};
 
   //   size_t bufferSize = mTimeFrameGPU->getConfig().tmpCUBBufferSize;
   //   int excLas, nLas, nLines;

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
@@ -479,9 +479,13 @@ void VertexerTraitsGPU::computeTracklets()
   if (!mTimeFrameGPU->getClusters().size()) {
     return;
   }
-  for (size_t part{0}; part < mTimeFrameGPU->getNPartions(); ++part) {
-    mTimeFrameGPU->loadPartitionData<gpu::Task::Vertexer>(part);
-  }
+  size_t offset{0};
+  do {
+    for (size_t part{0}; part < mTimeFrameGPU->getNPartions() && offset < mTimeFrameGPU->mNrof; ++part) {
+      offset += mTimeFrameGPU->loadPartitionData<gpu::Task::Vertexer>(part, offset);
+    }
+  } while (offset < mTimeFrameGPU->mNrof);
+  mTimeFrameGPU->unregisterHostMemory(3);
   // for (int rofId{0}; rofId < mTimeFrameGPU->getNrof(); ++rofId) {
   // const dim3 threadsPerBlock{gpu::utils::getBlockSize(mTimeFrameGPU->getNClustersLayer(rofId, 1))};
   // const dim3 blocksGrid{gpu::utils::getBlocksGrid(threadsPerBlock, mTimeFrameGPU->getNClustersLayer(rofId, 1))};

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
@@ -37,6 +37,8 @@
 #include "TFile.h"
 #endif
 
+#include "ITStrackingGPU/TracerGPU.h"
+
 namespace o2
 {
 namespace its
@@ -80,7 +82,6 @@ GPUh() void gpuThrowOnError()
 
 VertexerTraitsGPU::VertexerTraitsGPU()
 {
-  gpu::utils::host::gpuMalloc((void**)&mDeviceIndexTableUtils, sizeof(IndexTableUtils));
   setIsGPU(true);
 }
 
@@ -94,6 +95,7 @@ void VertexerTraitsGPU::initialise(const TrackingParameters& trackingParams)
   if (!mIndexTableUtils.getNzBins()) {
     updateVertexingParameters(mVrtParams);
   }
+  gpu::utils::host::gpuMalloc((void**)&mDeviceIndexTableUtils, sizeof(IndexTableUtils));
   gpu::utils::host::gpuMemcpyHostToDevice(mDeviceIndexTableUtils, &mIndexTableUtils, sizeof(mIndexTableUtils));
   mTimeFrameGPU->initialise(0, trackingParams, 3);
 }

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
@@ -95,9 +95,7 @@ void VertexerTraitsGPU::initialise(const TrackingParameters& trackingParams)
   if (!mIndexTableUtils.getNzBins()) {
     updateVertexingParameters(mVrtParams);
   }
-  gpu::utils::host::gpuMalloc((void**)&mDeviceIndexTableUtils, sizeof(IndexTableUtils));
-  gpu::utils::host::gpuMemcpyHostToDevice(mDeviceIndexTableUtils, &mIndexTableUtils, sizeof(mIndexTableUtils));
-  mTimeFrameGPU->initialise(0, trackingParams, 3);
+  mTimeFrameGPU->initialise(0, trackingParams, 3, &mIndexTableUtils);
 }
 
 namespace gpu
@@ -414,7 +412,7 @@ void VertexerTraitsGPU::computeTracklets()
   if (!mTimeFrameGPU->getClusters().size()) {
     return;
   }
-  mTimeFrameGPU->loadBatch<gpu::Task::Vertexer>(nullptr);
+  mTimeFrameGPU->loadBatch<gpu::Task::Vertexer>();
   // for (int rofId{0}; rofId < mTimeFrameGPU->getNrof(); ++rofId) {
   //     const dim3 threadsPerBlock{gpu::utils::host::getBlockSize(mTimeFrameGPU->getNClustersLayer(rofId, 1))};
   //     const dim3 blocksGrid{gpu::utils::host::getBlocksGrid(threadsPerBlock, mTimeFrameGPU->getNClustersLayer(rofId, 1))};

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
@@ -241,55 +241,52 @@ GPUg() void trackleterKernelMultipleRof(
 {
   const int phiBins{utils->getNphiBins()};
   const int zBins{utils->getNzBins()};
+  printOnThread(0, "===> %d %d ", startRofId, rofSize);
   for (unsigned int iRof{blockIdx.x}; iRof < rofSize; iRof += gridDim.x) {
     auto rof = iRof + startRofId;
-    auto* clustersInRofNextLayer = clustersNextLayer + sizeNextLClusters[rof];
-    auto* clustersInRofCurrentLayer = clustersCurrentLayer + sizeCurrentLClusters[rof];
-    auto nClustersNextLayer = sizeNextLClusters[iRof];
-    auto nClustersCurrentLayer = sizeCurrentLClusters[iRof];
+    auto* clustersInRofNextLayer = clustersNextLayer + (sizeNextLClusters[rof] - sizeNextLClusters[startRofId]);
+    auto* clustersInRofCurrentLayer = clustersCurrentLayer + (sizeCurrentLClusters[rof] - sizeCurrentLClusters[startRofId]);
+    auto nClustersNextLayer = sizeNextLClusters[rof + 1] - sizeNextLClusters[rof];
+    auto nClustersCurrentLayer = sizeCurrentLClusters[rof + 1] - sizeCurrentLClusters[rof];
     auto* indexTableNext = nextIndexTables + rof * (phiBins * zBins + 1);
-    auto* TrackletsRof = Tracklets + sizeCurrentLClusters[rof] * maxTrackletsPerCluster;
-    auto* foundTrackletsRof = foundTracklets + sizeCurrentLClusters[rof];
+    auto* TrackletsRof = Tracklets + (sizeCurrentLClusters[rof] - sizeCurrentLClusters[startRofId]) * maxTrackletsPerCluster;
+    auto* foundTrackletsRof = foundTracklets + (sizeCurrentLClusters[rof] - sizeCurrentLClusters[startRofId]);
     // single rof loop on layer1 clusters
-    printOnThread(0, "--> %d %d %d %d\n", rof, nClustersCurrentLayer, blockIdx.x, sizeNextLClusters[rof]);
     for (int iCurrentLayerClusterIndex = threadIdx.x; iCurrentLayerClusterIndex < nClustersCurrentLayer; iCurrentLayerClusterIndex += blockDim.x) {
       unsigned int storedTracklets{0};
       const size_t stride{iCurrentLayerClusterIndex * maxTrackletsPerCluster};
-      if ((int)stride == -1) {
-        printf("");
+      const Cluster& currentCluster = clustersInRofCurrentLayer[iCurrentLayerClusterIndex];
+      const int4 selectedBinsRect{VertexerTraits::getBinsRect(currentCluster, (int)Mode, 0.f, 50.f, phiCut / 2, *utils)};
+      if (selectedBinsRect.x != 0 || selectedBinsRect.y != 0 || selectedBinsRect.z != 0 || selectedBinsRect.w != 0) {
+        int phiBinsNum{selectedBinsRect.w - selectedBinsRect.y + 1};
+        if (phiBinsNum < 0) {
+          phiBinsNum += phiBins;
+        }
+        // loop on phi bins next layer
+        for (unsigned int iPhiBin{(unsigned int)selectedBinsRect.y}, iPhiCount{0}; iPhiCount < (unsigned int)phiBinsNum; iPhiBin = ++iPhiBin == phiBins ? 0 : iPhiBin, iPhiCount++) {
+          const int firstBinIndex{utils->getBinIndex(selectedBinsRect.x, iPhiBin)};
+          const int firstRowClusterIndex{indexTableNext[firstBinIndex]};
+          const int maxRowClusterIndex{indexTableNext[firstBinIndex + zBins]};
+          // loop on clusters next layer
+          for (int iNextLayerClusterIndex{firstRowClusterIndex}; iNextLayerClusterIndex < maxRowClusterIndex && iNextLayerClusterIndex < nClustersNextLayer; ++iNextLayerClusterIndex) {
+            const Cluster& nextCluster = clustersInRofNextLayer[iNextLayerClusterIndex];
+            if (o2::gpu::GPUCommonMath::Abs(currentCluster.phi - nextCluster.phi) < phiCut) {
+              if (storedTracklets < maxTrackletsPerCluster) {
+                if constexpr (Mode == TrackletMode::Layer0Layer1) {
+                  new (TrackletsRof + stride + storedTracklets) Tracklet{iNextLayerClusterIndex, iCurrentLayerClusterIndex, nextCluster, currentCluster, static_cast<int>(rof), static_cast<int>(rof)};
+                } else {
+                  new (TrackletsRof + stride + storedTracklets) Tracklet{iCurrentLayerClusterIndex, iNextLayerClusterIndex, currentCluster, nextCluster, static_cast<int>(rof), static_cast<int>(rof)};
+                }
+                ++storedTracklets;
+              }
+            }
+          }
+        }
       }
-      //   const Cluster& currentCluster = clustersInRofCurrentLayer[iCurrentLayerClusterIndex];
-      //   const int4 selectedBinsRect{VertexerTraits::getBinsRect(currentCluster, (int)Mode, 0.f, 50.f, phiCut / 2, *utils)};
-      //   if (selectedBinsRect.x != 0 || selectedBinsRect.y != 0 || selectedBinsRect.z != 0 || selectedBinsRect.w != 0) {
-      //     int phiBinsNum{selectedBinsRect.w - selectedBinsRect.y + 1};
-      //     if (phiBinsNum < 0) {
-      //       phiBinsNum += phiBins;
-      //     }
-      //     // loop on phi bins next layer
-      //     //   for (unsigned int iPhiBin{(unsigned int)selectedBinsRect.y}, iPhiCount{0}; iPhiCount < (unsigned int)phiBinsNum; iPhiBin = ++iPhiBin == phiBins ? 0 : iPhiBin, iPhiCount++) {
-      //     //     const int firstBinIndex{utils->getBinIndex(selectedBinsRect.x, iPhiBin)};
-      //     //     const int firstRowClusterIndex{indexTableNext[firstBinIndex]};
-      //     //     const int maxRowClusterIndex{indexTableNext[firstBinIndex + zBins]};
-      //     //     // loop on clusters next layer
-      //     //     for (int iNextLayerClusterIndex{firstRowClusterIndex}; iNextLayerClusterIndex < maxRowClusterIndex && iNextLayerClusterIndex < nClustersNextLayer; ++iNextLayerClusterIndex) {
-      //     //       const Cluster& nextCluster = clustersInRofNextLayer[iNextLayerClusterIndex];
-      //     //       if (o2::gpu::GPUCommonMath::Abs(currentCluster.phi - nextCluster.phi) < phiCut) {
-      //     //         if (storedTracklets < maxTrackletsPerCluster) {
-      //     //           if constexpr (Mode == TrackletMode::Layer0Layer1) {
-      //     //             new (TrackletsRof + stride + storedTracklets) Tracklet{iNextLayerClusterIndex, iCurrentLayerClusterIndex, nextCluster, currentCluster, static_cast<int>(rof), static_cast<int>(rof)};
-      //     //           } else {
-      //     //             new (TrackletsRof + stride + storedTracklets) Tracklet{iCurrentLayerClusterIndex, iNextLayerClusterIndex, currentCluster, nextCluster, static_cast<int>(rof), static_cast<int>(rof)};
-      //     //           }
-      //     //           ++storedTracklets;
-      //     //         }
-      //     //       }
-      //     //     }
-      //     //   }
-      //   }
-      //   foundTrackletsRof[iCurrentLayerClusterIndex] = storedTracklets;
-      //   if (storedTracklets >= maxTrackletsPerCluster) {
-      //     printf("gpu tracklet finder: some lines will be left behind for cluster %d. valid: %u max: %zu\n", iCurrentLayerClusterIndex, storedTracklets, maxTrackletsPerCluster);
-      //   }
+      foundTrackletsRof[iCurrentLayerClusterIndex] = storedTracklets;
+      if (storedTracklets >= maxTrackletsPerCluster) {
+        printf("gpu tracklet finder: some lines will be left behind for cluster %d. valid: %u max: %zu\n", iCurrentLayerClusterIndex, storedTracklets, maxTrackletsPerCluster);
+      }
     }
   }
 }
@@ -493,35 +490,35 @@ void VertexerTraitsGPU::computeTracklets()
   size_t offset{0};
   do {
     for (size_t part{0}; part < mTimeFrameGPU->getNPartions() && offset < mTimeFrameGPU->mNrof; ++part) {
-      auto rofs = mTimeFrameGPU->loadPartitionData<gpu::Task::Vertexer>(part, offset);
+      auto rofs = mTimeFrameGPU->loadChunkData<gpu::Task::Vertexer>(part, offset);
       gpu::trackleterKernelMultipleRof<TrackletMode::Layer0Layer1><<<1, 1, 0, mTimeFrameGPU->getStream(part).get()>>>(
-        mTimeFrameGPU->getPartition(part).getDeviceClusters(0),         // const Cluster* clustersNextLayer,    // 0 2
-        mTimeFrameGPU->getPartition(part).getDeviceClusters(1),         // const Cluster* clustersCurrentLayer, // 1 1
-        mTimeFrameGPU->getPartition(part).getDeviceNClustersROF(0),     // const int* sizeNextLClusters,
-        mTimeFrameGPU->getPartition(part).getDeviceNClustersROF(1),     // const int* sizeCurrentLClusters,
-        mTimeFrameGPU->getPartition(part).getDeviceIndexTables(0),      // const int* nextIndexTables,
-        mTimeFrameGPU->getPartition(part).getDeviceTracklets(0),        // Tracklet* Tracklets,
-        mTimeFrameGPU->getPartition(part).getDeviceNTrackletCluster(0), // int* foundTracklets,
-        mTimeFrameGPU->getDeviceIndexTableUtils(),                      // const IndexTableUtils* utils,
-        offset,                                                         // const unsigned int startRofId,
-        rofs,                                                           // const unsigned int rofSize,
-        mVrtParams.phiCut,                                              // const float phiCut,
-        mVrtParams.maxTrackletsPerCluster);                             // const size_t maxTrackletsPerCluster = 1e2
-      break;
+        mTimeFrameGPU->getChunk(part).getDeviceClusters(0),         // const Cluster* clustersNextLayer,    // 0 2
+        mTimeFrameGPU->getChunk(part).getDeviceClusters(1),         // const Cluster* clustersCurrentLayer, // 1 1
+        mTimeFrameGPU->getDeviceROframesClusters(0),                // const int* sizeNextLClusters,
+        mTimeFrameGPU->getDeviceROframesClusters(1),                // const int* sizeCurrentLClusters,
+        mTimeFrameGPU->getChunk(part).getDeviceIndexTables(0),      // const int* nextIndexTables,
+        mTimeFrameGPU->getChunk(part).getDeviceTracklets(0),        // Tracklet* Tracklets,
+        mTimeFrameGPU->getChunk(part).getDeviceNTrackletCluster(0), // int* foundTracklets,
+        mTimeFrameGPU->getDeviceIndexTableUtils(),                  // const IndexTableUtils* utils,
+        offset,                                                     // const unsigned int startRofId,
+        rofs,                                                       // const unsigned int rofSize,
+        mVrtParams.phiCut,                                          // const float phiCut,
+        mVrtParams.maxTrackletsPerCluster);                         // const size_t maxTrackletsPerCluster = 1e2
       // gpu::trackleterKernelMultipleRof<TrackletMode::Layer1Layer2><<<rofs, 1024, 0, mTimeFrameGPU->getStream(part).get()>>>(
-      //   mTimeFrameGPU->getPartition(part).getDeviceClusters(2),         // const Cluster* clustersNextLayer,    // 0 2
-      //   mTimeFrameGPU->getPartition(part).getDeviceClusters(1),         // const Cluster* clustersCurrentLayer, // 1 1
-      //   mTimeFrameGPU->getPartition(part).getDeviceNClustersROF(2), // const int* sizeNextLClusters,
-      //   mTimeFrameGPU->getPartition(part).getDeviceNClustersROF(1), // const int* sizeCurrentLClusters,
-      //   mTimeFrameGPU->getPartition(part).getDeviceIndexTables(2),      // const int* nextIndexTables,
-      //   mTimeFrameGPU->getPartition(part).getDeviceTracklets(1),        // Tracklet* Tracklets,
-      //   mTimeFrameGPU->getPartition(part).getDeviceNTrackletCluster(1), // int* foundTracklets,
-      //   mTimeFrameGPU->getPartition(part).getDeviceIndexTableUtils(),   // const IndexTableUtils* utils,
+      //   mTimeFrameGPU->getChunk(part).getDeviceClusters(2),         // const Cluster* clustersNextLayer,    // 0 2
+      //   mTimeFrameGPU->getChunk(part).getDeviceClusters(1),         // const Cluster* clustersCurrentLayer, // 1 1
+      //   mTimeFrameGPU->getChunk(part).getDeviceNClustersROF(2), // const int* sizeNextLClusters,
+      //   mTimeFrameGPU->getChunk(part).getDeviceNClustersROF(1), // const int* sizeCurrentLClusters,
+      //   mTimeFrameGPU->getChunk(part).getDeviceIndexTables(2),      // const int* nextIndexTables,
+      //   mTimeFrameGPU->getChunk(part).getDeviceTracklets(1),        // Tracklet* Tracklets,
+      //   mTimeFrameGPU->getChunk(part).getDeviceNTrackletCluster(1), // int* foundTracklets,
+      //   mTimeFrameGPU->getChunk(part).getDeviceIndexTableUtils(),   // const IndexTableUtils* utils,
       //   offset,                                                         // const unsigned int startRofId,
       //   rofs,                                                           // const unsigned int rofSize,
       //   mVrtParams.phiCut,                                              // const float phiCut,
       //   mVrtParams.maxTrackletsPerCluster);                             // const size_t maxTrackletsPerCluster = 1e2
       offset += rofs;
+      break;
     }
     break;
   } while (offset < mTimeFrameGPU->mNrof);

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
@@ -709,17 +709,16 @@ void VertexerTraitsGPU::computeTracklets()
         checkGPUError(cudaStreamSynchronize(mTimeFrameGPU->getStream(chunkId).get()));
         // Compute vertices
         for (int iRof{0}; iRof < rofs; ++iRof) {
-          auto offsetRofId = offset + iRof;
-          auto clustersL1offsetRof = mTimeFrameGPU->getDeviceROframesClusters(1)[offsetRofId] - mTimeFrameGPU->getDeviceROframesClusters(1)[offset];     // starting cluster offset for this ROF
-          auto nClustersL1Rof = mTimeFrameGPU->getDeviceROframesClusters(1)[offsetRofId + 1] - mTimeFrameGPU->getDeviceROframesClusters(1)[offsetRofId]; // number of clusters for this ROF
-          auto linesOffsetRof = exclusiveFoundLinesHost[clustersL1offsetRof];                                                                            // starting line offset for this ROF
+          auto rof = offset + iRof;
+          auto clustersL1offsetRof = mTimeFrameGPU->getROframeClusters(1)[rof] - mTimeFrameGPU->getROframeClusters(1)[offset]; // starting cluster offset for this ROF
+          auto nClustersL1Rof = mTimeFrameGPU->getROframeClusters(1)[rof + 1] - mTimeFrameGPU->getROframeClusters(1)[rof];     // number of clusters for this ROF
+          auto linesOffsetRof = exclusiveFoundLinesHost[clustersL1offsetRof];                                                  // starting line offset for this ROF
           auto nLinesRof = exclusiveFoundLinesHost[clustersL1offsetRof + nClustersL1Rof] - linesOffsetRof;
-          LOGP(info, "rof: {} lines: {}", offsetRofId, nLinesRof);
-          // gsl::span<o2::its::Line> linesinRof(lines.data() + linesOffsetRof, nLinesRof);
-          // std::vector<bool> usedLines;
-          // std::vector<ClusterLines> clusterLines;
-          // usedLines.reserve(linesinRof.size());
-          // computeVerticesInRof(offsetRofId, linesinRof, usedLines, clusterLines);
+          gsl::span<o2::its::Line> linesinRof(lines.data() + linesOffsetRof, nLinesRof);
+          std::vector<bool> usedLines;
+          std::vector<ClusterLines> clusterLines;
+          usedLines.reserve(linesinRof.size());
+          computeVerticesInRof(rof, linesinRof, usedLines, clusterLines);
         }
       };
 

--- a/Detectors/ITSMFT/ITS/tracking/GPU/hip/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/hip/CMakeLists.txt
@@ -38,6 +38,7 @@ if(HIP_ENABLED)
                          TimeFrameGPU.hip.cxx
                          Stream.hip.cxx
                          TrackerTraitsGPU.hip.cxx
+                         TracerGPU.hip.cxx
                          VertexerTraitsGPU.hip.cxx
                          Utils.hip.cxx
                  PUBLIC_INCLUDE_DIRECTORIES ../

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
@@ -161,7 +161,7 @@ struct TimeFrameGPUConfig {
   size_t tmpCUBBufferSize = 1e5; // In average in pp events there are required 4096 bytes
   size_t maxTrackletsPerCluster = 1e2;
   size_t clustersPerLayerCapacity = 2.5e5;
-  size_t clustersPerROfCapacity = 1e4;
+  size_t clustersPerROfCapacity = 5e2;
   size_t trackletsCapacity = maxTrackletsPerCluster * clustersPerLayerCapacity;
   size_t validatedTrackletsCapacity = 1e5;
   size_t cellsLUTsize = validatedTrackletsCapacity;
@@ -169,6 +169,9 @@ struct TimeFrameGPUConfig {
   size_t maxCentroidsXYCapacity = std::ceil(maxLinesCapacity * (maxLinesCapacity - 1) / (float)2);
   size_t maxVerticesCapacity = 10;
   size_t nMaxROFs = 1e3;
+  size_t partitionStreamRatio = 1;
+  size_t nStreams = 3;
+  size_t maxTotalMemoryGB = 8;
 
   VertexerHistogramsConfiguration histConf; // <==== split into separate configs
 };

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
@@ -116,38 +116,6 @@ struct VertexingParameters {
   int nThreads = 1;
 };
 
-struct VertexerHistogramsConfiguration {
-  VertexerHistogramsConfiguration() = default;
-  VertexerHistogramsConfiguration(int nBins[3],
-                                  int binSpan[3],
-                                  float lowBoundaries[3],
-                                  float highBoundaries[3]);
-  int nBinsXYZ[3] = {402, 402, 4002};
-  int binSpanXYZ[3] = {2, 2, 4};
-  float lowHistBoundariesXYZ[3] = {-1.98f, -1.98f, -40.f};
-  float highHistBoundariesXYZ[3] = {1.98f, 1.98f, 40.f};
-  float binSizeHistX = (highHistBoundariesXYZ[0] - lowHistBoundariesXYZ[0]) / (nBinsXYZ[0] - 1);
-  float binSizeHistY = (highHistBoundariesXYZ[1] - lowHistBoundariesXYZ[1]) / (nBinsXYZ[1] - 1);
-  float binSizeHistZ = (highHistBoundariesXYZ[2] - lowHistBoundariesXYZ[2]) / (nBinsXYZ[2] - 1);
-};
-
-inline VertexerHistogramsConfiguration::VertexerHistogramsConfiguration(int nBins[3],
-                                                                        int binSpan[3],
-                                                                        float lowBoundaries[3],
-                                                                        float highBoundaries[3])
-{
-  for (int i{0}; i < 3; ++i) {
-    nBinsXYZ[i] = nBins[i];
-    binSpanXYZ[i] = binSpan[i];
-    lowHistBoundariesXYZ[i] = lowBoundaries[i];
-    highHistBoundariesXYZ[i] = highBoundaries[i];
-  }
-
-  binSizeHistX = (highHistBoundariesXYZ[0] - lowHistBoundariesXYZ[0]) / (nBinsXYZ[0] - 1);
-  binSizeHistY = (highHistBoundariesXYZ[1] - lowHistBoundariesXYZ[1]) / (nBinsXYZ[1] - 1);
-  binSizeHistZ = (highHistBoundariesXYZ[2] - lowHistBoundariesXYZ[2]) / (nBinsXYZ[2] - 1);
-}
-
 struct TimeFrameGPUConfig {
   TimeFrameGPUConfig() = default;
   TimeFrameGPUConfig(size_t cubBufferSize,
@@ -166,13 +134,12 @@ struct TimeFrameGPUConfig {
   size_t validatedTrackletsCapacity = 1e5;
   size_t cellsLUTsize = validatedTrackletsCapacity;
   size_t maxLinesCapacity = 1e2;
-  size_t maxCentroidsXYCapacity = std::ceil(maxLinesCapacity * (maxLinesCapacity - 1) / (float)2);
   size_t maxVerticesCapacity = 10;
   size_t nMaxROFs = 1e3;
   size_t nTimeFramePartitions = 3;
-  size_t maxGPUMemoryGB = 8;
+  int maxGPUMemoryGB = -1;
 
-  VertexerHistogramsConfiguration histConf; // <==== split into separate configs
+  // VertexerHistogramsConfiguration histConf; // <==== split into separate configs
 };
 
 inline TimeFrameGPUConfig::TimeFrameGPUConfig(size_t cubBufferSize,
@@ -189,7 +156,6 @@ inline TimeFrameGPUConfig::TimeFrameGPUConfig(size_t cubBufferSize,
                                                                 maxVerticesCapacity{maxVertCap},
                                                                 nMaxROFs{maxROFs}
 {
-  maxCentroidsXYCapacity = std::ceil(maxLinesCapacity * (maxLinesCapacity - 1) / 2);
   trackletsCapacity = maxTrackletsPerCluster * clustersPerLayerCapacity;
 }
 

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
@@ -106,7 +106,6 @@ struct VertexingParameters {
   float histPairCut = 0.04f;
   float tanLambdaCut = 0.002f; // tanLambda = deltaZ/deltaR
   float lowMultXYcut2 = 0.01f; // XY cut for low-multiplicity pile up
-  float baseBeamError = 0.005f;
   float maxZPositionAllowed = 25.f;
   int clusterContributorsCut = 16;
   int maxTrackletsPerCluster = 2e3;
@@ -136,7 +135,7 @@ struct TimeFrameGPUConfig {
   size_t maxLinesCapacity = 1e2;
   size_t maxVerticesCapacity = 10;
   size_t nMaxROFs = 1e3;
-  size_t nTimeFramePartitions = 3;
+  size_t nTimeFrameChunks = 3;
   int maxGPUMemoryGB = -1;
 
   // VertexerHistogramsConfiguration histConf; // <==== split into separate configs

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
@@ -169,9 +169,8 @@ struct TimeFrameGPUConfig {
   size_t maxCentroidsXYCapacity = std::ceil(maxLinesCapacity * (maxLinesCapacity - 1) / (float)2);
   size_t maxVerticesCapacity = 10;
   size_t nMaxROFs = 1e3;
-  size_t partitionStreamRatio = 1;
-  size_t nStreams = 3;
-  size_t maxTotalMemoryGB = 8;
+  size_t nTimeFramePartitions = 3;
+  size_t maxGPUMemoryGB = 8;
 
   VertexerHistogramsConfiguration histConf; // <==== split into separate configs
 };

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Definitions.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Definitions.h
@@ -17,6 +17,7 @@
 
 // #define CA_DEBUG
 // #define VTX_DEBUG
+#define __USE_GPU_TRACER__
 
 template <typename T>
 void discardResult(const T&)

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/IndexTableUtils.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/IndexTableUtils.h
@@ -36,6 +36,7 @@ class IndexTableUtils
   GPUhdi() int getPhiBinIndex(const float) const;
   GPUhdi() int getBinIndex(const int, const int) const;
   GPUhdi() int countRowSelectedBins(const int*, const int, const int, const int) const;
+  GPUhdi() void print() const;
 
   GPUhdi() int getNzBins() const { return mNzBins; }
   GPUhdi() int getNphiBins() const { return mNphiBins; }
@@ -90,6 +91,14 @@ GPUhdi() int IndexTableUtils::countRowSelectedBins(const int* indexTable, const 
   const int maxBinIndex{firstBinIndex + maxZBinIndex - minZBinIndex + 1};
 
   return indexTable[maxBinIndex] - indexTable[firstBinIndex];
+}
+
+GPUhdi() void IndexTableUtils::print() const
+{
+  printf("NzBins: %d, NphiBins: %d, InversePhiBinSize: %f\n", mNzBins, mNphiBins, mInversePhiBinSize);
+  for (int iLayer{0}; iLayer < 7; ++iLayer) {
+    printf("Layer %d: Z: %f, InverseZBinSize: %f\n", iLayer, mLayerZ[iLayer], mInverseZBinSize[iLayer]);
+  }
 }
 } // namespace its
 } // namespace o2

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -120,6 +120,7 @@ class TimeFrame
   gsl::span<const Cluster> getClustersOnLayer(int rofId, int layerId) const;
   gsl::span<const Cluster> getClustersPerROFrange(int rofMin, int range, int layerId) const;
   gsl::span<const Cluster> getUnsortedClustersOnLayer(int rofId, int layerId) const;
+  gsl::span<const int> getROframesClustersPerROFrange(int rofMin, int range, int layerId) const;
   gsl::span<int> getIndexTable(int rofId, int layerId);
   std::vector<int>& getIndexTableWhole(int layerId) { return mIndexTables[layerId]; }
   const std::vector<TrackingFrameInfo>& getTrackingFrameInfoOnLayer(int layerId) const;
@@ -341,6 +342,16 @@ inline gsl::span<const Cluster> TimeFrame::getClustersPerROFrange(int rofMin, in
   int startIdx{mROframesClusters[layerId][rofMin]}; // First cluster of rofMin
   int endIdx{mROframesClusters[layerId][rofMin + std::min(range, mNrof - rofMin)]};
   return {&mClusters[layerId][startIdx], static_cast<gsl::span<Cluster>::size_type>(endIdx - startIdx)};
+}
+
+inline gsl::span<const int> TimeFrame::getROframesClustersPerROFrange(int rofMin, int range, int layerId) const
+{
+  if (rofMin < 0 || rofMin >= mNrof) {
+    return gsl::span<const int>();
+  }
+  int startIdx{rofMin}; // First cluster of rofMin
+  int endIdx{rofMin + std::min(range, mNrof - rofMin)};
+  return {&mROframesClusters[layerId][startIdx], static_cast<gsl::span<int>::size_type>(endIdx - startIdx)};
 }
 
 inline int TimeFrame::getClusterROF(int iLayer, int iCluster)

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -346,11 +346,8 @@ inline gsl::span<const Cluster> TimeFrame::getClustersPerROFrange(int rofMin, in
 
 inline gsl::span<const int> TimeFrame::getROframesClustersPerROFrange(int rofMin, int range, int layerId) const
 {
-  if (rofMin < 0 || rofMin >= mNrof) {
-    return gsl::span<const int>();
-  }
   int startIdx{rofMin}; // First cluster of rofMin
-  int endIdx{rofMin + std::min(range, mNrof - rofMin)};
+  int endIdx{rofMin + std::min(range, mNrof - rofMin)}; // need to decrease by 1?
   return {&mROframesClusters[layerId][startIdx], static_cast<gsl::span<int>::size_type>(endIdx - startIdx)};
 }
 

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -118,6 +118,7 @@ class TimeFrame
 
   gsl::span<Cluster> getClustersOnLayer(int rofId, int layerId);
   gsl::span<const Cluster> getClustersOnLayer(int rofId, int layerId) const;
+  gsl::span<const Cluster> getClustersPerROFrange(int rofMin, int range, int layerId) const;
   gsl::span<const Cluster> getUnsortedClustersOnLayer(int rofId, int layerId) const;
   gsl::span<int> getIndexTable(int rofId, int layerId);
   std::vector<int>& getIndexTableWhole(int layerId) { return mIndexTables[layerId]; }
@@ -330,6 +331,16 @@ inline gsl::span<const Cluster> TimeFrame::getClustersOnLayer(int rofId, int lay
   }
   int startIdx{mROframesClusters[layerId][rofId]};
   return {&mClusters[layerId][startIdx], static_cast<gsl::span<Cluster>::size_type>(mROframesClusters[layerId][rofId + 1] - startIdx)};
+}
+
+inline gsl::span<const Cluster> TimeFrame::getClustersPerROFrange(int rofMin, int range, int layerId) const
+{
+  if (rofMin < 0 || rofMin >= mNrof) {
+    return gsl::span<const Cluster>();
+  }
+  int startIdx{mROframesClusters[layerId][rofMin]}; // First cluster of rofMin
+  int endIdx{mROframesClusters[layerId][rofMin + std::min(range, mNrof - rofMin)]};
+  return {&mClusters[layerId][startIdx], static_cast<gsl::span<Cluster>::size_type>(endIdx - startIdx)};
 }
 
 inline int TimeFrame::getClusterROF(int iLayer, int iCluster)

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -178,7 +178,7 @@ class TimeFrame
   gsl::span<const MCCompLabel> getLabelsFoundTracklets(int rofId, int combId) const;
   gsl::span<int> getNTrackletsCluster(int rofId, int combId);
   uint32_t getTotalTrackletsTF(const int iLayer) { return mTotalTracklets[iLayer]; }
-
+  int getTotalClustersPerROFrange(int rofMin, int range, int layerId) const;
   // \Vertexer
 
   void initialiseRoadLabels();
@@ -350,30 +350,34 @@ inline gsl::span<const Cluster> TimeFrame::getClustersPerROFrange(int rofMin, in
     return gsl::span<const Cluster>();
   }
   int startIdx{mROframesClusters[layerId][rofMin]}; // First cluster of rofMin
-  int endIdx{mROframesClusters[layerId][std::min(rofMin + range, mNrof) - 1]};
+  int endIdx{mROframesClusters[layerId][std::min(rofMin + range, mNrof)]};
   return {&mClusters[layerId][startIdx], static_cast<gsl::span<Cluster>::size_type>(endIdx - startIdx)};
 }
 
 inline gsl::span<const int> TimeFrame::getROframesClustersPerROFrange(int rofMin, int range, int layerId) const
 {
-  int startIdx{rofMin}; // First cluster of rofMin
-  int endIdx{std::min(rofMin + range, mNrof) - 1};
-  return {&mROframesClusters[layerId][startIdx], static_cast<gsl::span<int>::size_type>(endIdx - startIdx)};
+  int chkdRange{std::min(range, mNrof - rofMin)};
+  return {&mROframesClusters[layerId][rofMin], static_cast<gsl::span<int>::size_type>(chkdRange)};
 }
 
 inline gsl::span<const int> TimeFrame::getNClustersROFrange(int rofMin, int range, int layerId) const
 {
-  int startIdx{rofMin};
-  int endIdx{std::min(rofMin + range, mNrof) - 1};
-  return {&mNClustersPerROF[layerId][startIdx], static_cast<gsl::span<int>::size_type>(endIdx - startIdx)};
+  int chkdRange{std::min(range, mNrof - rofMin)};
+  return {&mNClustersPerROF[layerId][rofMin], static_cast<gsl::span<int>::size_type>(chkdRange)};
+}
+
+inline int TimeFrame::getTotalClustersPerROFrange(int rofMin, int range, int layerId) const
+{
+  int startIdx{rofMin}; // First cluster of rofMin
+  int endIdx{std::min(rofMin + range, mNrof)};
+  return mROframesClusters[layerId][endIdx] - mROframesClusters[layerId][startIdx];
 }
 
 inline gsl::span<const int> TimeFrame::getIndexTablePerROFrange(int rofMin, int range, int layerId) const
 {
   const int iTableSize{mIndexTableUtils.getNphiBins() * mIndexTableUtils.getNzBins() + 1};
-  int startIdx{rofMin};
-  int endIdx{std::min(startIdx + range, mNrof) - 1};
-  return {&mIndexTables[layerId][startIdx * iTableSize], static_cast<gsl::span<int>::size_type>((endIdx - startIdx) * iTableSize)};
+  int chkdRange{std::min(range, mNrof - rofMin)};
+  return {&mIndexTables[layerId][rofMin * iTableSize], static_cast<gsl::span<int>::size_type>(chkdRange * iTableSize)};
 }
 
 inline int TimeFrame::getClusterROF(int iLayer, int iCluster)

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -121,6 +121,7 @@ class TimeFrame
   gsl::span<const Cluster> getClustersPerROFrange(int rofMin, int range, int layerId) const;
   gsl::span<const Cluster> getUnsortedClustersOnLayer(int rofId, int layerId) const;
   gsl::span<const int> getROframesClustersPerROFrange(int rofMin, int range, int layerId) const;
+  gsl::span<const int> getROframeClusters(int layerId) const;
   gsl::span<const int> getNClustersROFrange(int rofMin, int range, int layerId) const;
   gsl::span<const int> getIndexTablePerROFrange(int rofMin, int range, int layerId) const;
   gsl::span<int> getIndexTable(int rofId, int layerId);
@@ -210,7 +211,6 @@ class TimeFrame
   std::vector<std::vector<int>> mClusterExternalIndices;
   std::vector<std::vector<int>> mROframesClusters;
   std::vector<std::vector<int>> mNClustersPerROF;
-  std::vector<std::vector<int>> mROframesClustersParted; // stores the exclusive sum of ROF clusters for each partition GPU specific
   std::vector<std::vector<int>> mIndexTables;
   std::vector<std::vector<int>> mTrackletsLookupTable;
   std::vector<std::vector<unsigned char>> mUsedClusters;
@@ -321,6 +321,11 @@ inline float TimeFrame::getBeamX() const { return mBeamPos[0]; }
 
 inline float TimeFrame::getBeamY() const { return mBeamPos[1]; }
 
+inline gsl::span<const int> TimeFrame::getROframeClusters(int layerId) const
+{
+  return {&mROframesClusters[layerId][0], static_cast<gsl::span<const int>::size_type>(mROframesClusters[layerId].size())};
+}
+
 inline gsl::span<Cluster> TimeFrame::getClustersOnLayer(int rofId, int layerId)
 {
   if (rofId < 0 || rofId >= mNrof) {
@@ -362,14 +367,6 @@ inline gsl::span<const int> TimeFrame::getNClustersROFrange(int rofMin, int rang
   int endIdx{std::min(rofMin + range, mNrof) - 1};
   return {&mNClustersPerROF[layerId][startIdx], static_cast<gsl::span<int>::size_type>(endIdx - startIdx)};
 }
-
-// inline gsl::span<const int> TimeFrame::getComputedROframesClusters(int rofMin, int range, int layerId) const
-// {
-//   int startIdx{rofMin};
-//   int endIdx{std::min(rofMin + range, mNrof) - 1};
-
-// }
-
 
 inline gsl::span<const int> TimeFrame::getIndexTablePerROFrange(int rofMin, int range, int layerId) const
 {

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
@@ -73,6 +73,24 @@ struct TrackerParamConfig : public o2::conf::ConfigurableParamHelper<TrackerPara
   O2ParamDef(TrackerParamConfig, "ITSCATrackerParam");
 };
 
+struct GpuRecoParamConfig : public o2::conf::ConfigurableParamHelper<GpuRecoParamConfig> {
+  // GPU-specific parameters
+  size_t tmpCUBBufferSize = 1e5; // In average in pp events there are required 4096 bytes
+  size_t maxTrackletsPerCluster = 1e2;
+  size_t clustersPerLayerCapacity = 2.5e5;
+  size_t clustersPerROfCapacity = 5e2;
+  size_t trackletsCapacity = maxTrackletsPerCluster * clustersPerLayerCapacity;
+  size_t validatedTrackletsCapacity = 1e5;
+  size_t cellsLUTsize = validatedTrackletsCapacity;
+  size_t maxLinesCapacity = 1e2;
+  size_t maxVerticesCapacity = 10;
+  size_t nMaxROFs = 1e3;
+  size_t nTimeFramePartitions = 3;
+  int maxGPUMemoryGB = -1;
+
+  O2ParamDef(GpuRecoParamConfig, "ITSGpuRecoParam");
+};
+
 } // namespace its
 } // namespace o2
 #endif

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
@@ -68,7 +68,11 @@ class VertexerTraits
   virtual void computeVertices();
   virtual void adoptTimeFrame(TimeFrame* tf);
   virtual void updateVertexingParameters(const VertexingParameters& vrtPar);
-  // virtual void computeHistVertices();
+
+  void computeVerticesInRof(const int,
+                            gsl::span<o2::its::Line>&,
+                            std::vector<bool>&,
+                            std::vector<ClusterLines>&);
 
   VertexingParameters getVertexingParameters() const { return mVrtParams; }
   static const std::vector<std::pair<int, int>> selectClusters(const int* indexTable,

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
@@ -69,10 +69,7 @@ class VertexerTraits
   virtual void adoptTimeFrame(TimeFrame* tf);
   virtual void updateVertexingParameters(const VertexingParameters& vrtPar);
 
-  void computeVerticesInRof(const int,
-                            gsl::span<o2::its::Line>&,
-                            std::vector<bool>&,
-                            std::vector<ClusterLines>&);
+  void computeVerticesInRof(gsl::span<const o2::its::Line>&);
 
   VertexingParameters getVertexingParameters() const { return mVrtParams; }
   static const std::vector<std::pair<int, int>> selectClusters(const int* indexTable,

--- a/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
@@ -74,6 +74,7 @@ TimeFrame::TimeFrame(int nLayers)
   mClusterExternalIndices.resize(nLayers);
   mUsedClusters.resize(nLayers);
   mROframesClusters.resize(nLayers, {0}); /// TBC: if resetting the timeframe is required, then this has to be done
+  mNClustersPerROF.resize(nLayers);
   mTrackletsIndexROf.resize(2, {0});
 }
 
@@ -140,6 +141,7 @@ int TimeFrame::loadROFrameData(const o2::itsmft::ROFRecord& rof, gsl::span<const
   }
 
   for (unsigned int iL{0}; iL < mUnsortedClusters.size(); ++iL) {
+    mNClustersPerROF[iL].push_back(mUnsortedClusters[iL].size() - mROframesClusters[iL].back());
     mROframesClusters[iL].push_back(mUnsortedClusters[iL].size());
     if (iL < 2) {
       mTrackletsIndexROf[iL].push_back(mUnsortedClusters[1].size()); // Tracklets used in vertexer are always computed starting from L1
@@ -199,6 +201,7 @@ int TimeFrame::loadROFrameData(gsl::span<o2::itsmft::ROFRecord> rofs,
       addClusterExternalIndexToLayer(layer, clusterId);
     }
     for (unsigned int iL{0}; iL < mUnsortedClusters.size(); ++iL) {
+      mNClustersPerROF[iL].push_back(mUnsortedClusters[iL].size() - mROframesClusters[iL].back());
       mROframesClusters[iL].push_back(mUnsortedClusters[iL].size());
     }
     mNrof++;
@@ -491,6 +494,18 @@ void TimeFrame::printROFoffsets()
   for (unsigned int iLayer{0}; iLayer < mROframesClusters.size(); ++iLayer) {
     std::cout << "Layer " << iLayer << std::endl;
     for (auto value : mROframesClusters[iLayer]) {
+      std::cout << value << "\t";
+    }
+    std::cout << std::endl;
+  }
+}
+
+void TimeFrame::printNClsPerROF()
+{
+  std::cout << "--------" << std::endl;
+  for (unsigned int iLayer{0}; iLayer < mNClustersPerROF.size(); ++iLayer) {
+    std::cout << "Layer " << iLayer << std::endl;
+    for (auto& value : mNClustersPerROF[iLayer]) {
       std::cout << value << "\t";
     }
     std::cout << std::endl;

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackingConfigParam.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackingConfigParam.cxx
@@ -18,8 +18,10 @@ namespace its
 {
 static auto& sVertexerParamITS = o2::its::VertexerParamConfig::Instance();
 static auto& sCATrackerParamITS = o2::its::TrackerParamConfig::Instance();
+static auto& sGpuRecoParamITS = o2::its::GpuRecoParamConfig::Instance();
 
 O2ParamImpl(o2::its::VertexerParamConfig);
 O2ParamImpl(o2::its::TrackerParamConfig);
+O2ParamImpl(o2::its::GpuRecoParamConfig);
 } // namespace its
 } // namespace o2

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackingLinkDef.h
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackingLinkDef.h
@@ -30,4 +30,7 @@
 #pragma link C++ class o2::its::TrackerParamConfig + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper <o2::its::TrackerParamConfig> + ;
 
+#pragma link C++ class o2::its::GpuRecoParamConfig + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper <o2::its::GpuRecoParamConfig> + ;
+
 #endif

--- a/Detectors/ITSMFT/ITS/tracking/src/Vertexer.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Vertexer.cxx
@@ -58,6 +58,7 @@ void Vertexer::findVertices()
 void Vertexer::getGlobalConfiguration()
 {
   auto& vc = o2::its::VertexerParamConfig::Instance();
+  auto& grc = o2::its::GpuRecoParamConfig::Instance();
 
   VertexingParameters verPar;
   verPar.allowSingleContribClusters = vc.allowSingleContribClusters;

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -344,6 +344,8 @@ void VertexerTraits::computeVertices()
   std::vector<int> noClustersVec(mTimeFrame->getNrof(), 0);
   for (int rofId{0}; rofId < mTimeFrame->getNrof(); ++rofId) {
     const int numTracklets{static_cast<int>(mTimeFrame->getLines(rofId).size())};
+    printf("rof: %d -> %d lines.\n", rofId, numTracklets);
+
     std::vector<bool> usedTracklets(numTracklets, false);
     for (int line1{0}; line1 < numTracklets; ++line1) {
       if (usedTracklets[line1]) {
@@ -353,7 +355,11 @@ void VertexerTraits::computeVertices()
         if (usedTracklets[line2]) {
           continue;
         }
-        if (Line::getDCA(mTimeFrame->getLines(rofId)[line1], mTimeFrame->getLines(rofId)[line2]) < mVrtParams.pairCut) {
+        auto dca{Line::getDCA(mTimeFrame->getLines(rofId)[line1], mTimeFrame->getLines(rofId)[line2])};
+        if (dca < mVrtParams.pairCut) {
+          printf("rof: %d, line1: %d, line2: %d, dca: %f\n", rofId, line1, line2, dca);
+          mTimeFrame->getLines(rofId)[line1].print();
+          mTimeFrame->getLines(rofId)[line2].print();
           mTimeFrame->getTrackletClusters(rofId).emplace_back(line1, mTimeFrame->getLines(rofId)[line1], line2, mTimeFrame->getLines(rofId)[line2]);
           std::array<float, 3> tmpVertex{mTimeFrame->getTrackletClusters(rofId).back().getVertex()};
           if (tmpVertex[0] * tmpVertex[0] + tmpVertex[1] * tmpVertex[1] > 4.f) {
@@ -497,120 +503,125 @@ void VertexerTraits::setNThreads(int n)
   LOGP(info, "Setting seeding vertexer with {} threads.", mNThreads);
 }
 
-// void VertexerTraits::computeHistVertices()
-// {
-//   o2::its::VertexerHistogramsConfiguration histConf;
-//   std::vector<boost::histogram::axis::regular<float>> axes;
-//   axes.reserve(3);
-//   for (size_t iAxis{0}; iAxis < 3; ++iAxis) {
-//     axes.emplace_back(histConf.nBinsXYZ[iAxis] - 1, histConf.lowHistBoundariesXYZ[iAxis], histConf.highHistBoundariesXYZ[iAxis]);
-//   }
+void VertexerTraits::computeVerticesInRof(const int rofId, gsl::span<o2::its::Line>& lines, std::vector<bool>& usedLines, std::vector<ClusterLines>& clusterLines)
+{
+  usedLines.resize(lines.size(), false);
+  clusterLines.clear();
+  clusterLines.reserve(lines.size());
+  const int numTracklets{static_cast<int>(lines.size())};
+  printf("rof: %d -> %d lines.\n", rofId, numTracklets);
 
-//   auto histX = boost::histogram::make_histogram(axes[0]);
-//   auto histY = boost::histogram::make_histogram(axes[1]);
-//   auto histZ = boost::histogram::make_histogram(axes[2]);
+  // std::vector<bool> usedTracklets(numTracklets, false);
+  // for (int line1{0}; line1 < numTracklets; ++line1) {
+  //   if (usedLines[line1]) {
+  //     continue;
+  //   }
+  //   for (int line2{line1 + 1}; line2 < numTracklets; ++line2) {
+  //     if (usedLines[line2]) {
+  //       continue;
+  //     }
+  //     auto dca{Line::getDCA(lines[line1], lines[line2])};
+  //     if (dca < mVrtParams.pairCut) {
+  //       clusterLines.emplace_back(line1, lines[line1], line2, lines[line2]);
+  //       std::array<float, 3> tmpVertex{clusterLines.back().getVertex()};
+  //       if (tmpVertex[0] * tmpVertex[0] + tmpVertex[1] * tmpVertex[1] > 4.f) {
+  //         clusterLines.pop_back();
+  //         break;
+  //       }
+  //       usedLines[line1] = true;
+  //       usedLines[line2] = true;
+  //       for (int tracklet3{0}; tracklet3 < numTracklets; ++tracklet3) {
+  //         if (usedLines[tracklet3]) {
+  //           continue;
+  //         }
+  //         if (Line::getDistanceFromPoint(lines[tracklet3], tmpVertex) < mVrtParams.pairCut) {
+  //           clusterLines.back().add(tracklet3, lines[tracklet3]);
+  //           usedLines[tracklet3] = true;
+  //           tmpVertex = clusterLines.back().getVertex();
+  //         }
+  //       }
+  //       break;
+  //     }
+  //   }
+  // }
+  // if (mVrtParams.allowSingleContribClusters) {
+  //   auto beamLine = Line{{mTimeFrame->getBeamX(), mTimeFrame->getBeamY(), -50.f}, {mTimeFrame->getBeamX(), mTimeFrame->getBeamY(), 50.f}}; // use beam position as contributor
+  //   for (size_t iLine{0}; iLine < numTracklets; ++iLine) {
+  //     if (!usedLines[iLine]) {
+  //       auto dca = Line::getDCA(lines[iLine], beamLine);
+  //       if (dca < mVrtParams.pairCut) {
+  //         clusterLines.emplace_back(iLine, lines[iLine], -1, beamLine); // beamline must be passed as second line argument
+  //       }
+  //     }
+  //   }
+  // }
 
-//   // Loop over lines, calculate transverse vertices within beampipe and fill XY histogram to find pseudobeam projection
-//   for (size_t iTracklet1{0}; iTracklet1 < mTracklets.size(); ++iTracklet1) {
-//     for (size_t iTracklet2{iTracklet1 + 1}; iTracklet2 < mTracklets.size(); ++iTracklet2) {
-//       if (Line::getDCA(mTracklets[iTracklet1], mTracklets[iTracklet2]) < mVrtParams.histPairCut) {
-//         ClusterLines cluster{mTracklets[iTracklet1], mTracklets[iTracklet2]};
-//         if (cluster.getVertex()[0] * cluster.getVertex()[0] + cluster.getVertex()[1] * cluster.getVertex()[1] < 1.98f * 1.98f) {
-//           histX(cluster.getVertex()[0]);
-//           histY(cluster.getVertex()[1]);
-//         }
-//       }
-//     }
-//   }
+  // // Cluster merging
+  // std::sort(clusterLines.begin(), clusterLines.end(), [](ClusterLines& cluster1, ClusterLines& cluster2) { return cluster1.getSize() > cluster2.getSize(); });
+  // size_t nClusters{clusterLines.size()};
+  // for (int iCluster1{0}; iCluster1 < nClusters; ++iCluster1) {
+  //   std::array<float, 3> vertex1{clusterLines[iCluster1].getVertex()};
+  //   std::array<float, 3> vertex2{};
+  //   for (int iCluster2{iCluster1 + 1}; iCluster2 < nClusters; ++iCluster2) {
+  //     vertex2 = clusterLines[iCluster2].getVertex();
+  //     if (std::abs(vertex1[2] - vertex2[2]) < mVrtParams.clusterCut) {
+  //       float distance{(vertex1[0] - vertex2[0]) * (vertex1[0] - vertex2[0]) +
+  //                      (vertex1[1] - vertex2[1]) * (vertex1[1] - vertex2[1]) +
+  //                      (vertex1[2] - vertex2[2]) * (vertex1[2] - vertex2[2])};
+  //       if (distance < mVrtParams.pairCut * mVrtParams.pairCut) {
+  //         for (auto label : clusterLines[iCluster2].getLabels()) {
+  //           clusterLines[iCluster1].add(label, lines[label]);
+  //           vertex1 = clusterLines[iCluster1].getVertex();
+  //         }
+  //         clusterLines.erase(clusterLines.begin() + iCluster2);
+  //         --iCluster2;
+  //         --nClusters;
+  //       }
+  //     }
+  //   }
+  // }
 
-//   // Try again to use std::max_element as soon as boost is upgraded to 1.71...
-//   // atm you can iterate over histograms, not really possible to get bin index. Need to use iterate(histogram)
-//   int maxXBinContent{0};
-//   int maxYBinContent{0};
-//   int maxXIndex{0};
-//   int maxYIndex{0};
-//   for (auto x : indexed(histX)) {
-//     if (x.get() > maxXBinContent) {
-//       maxXBinContent = x.get();
-//       maxXIndex = x.index();
-//     }
-//   }
-
-//   for (auto y : indexed(histY)) {
-//     if (y.get() > maxYBinContent) {
-//       maxYBinContent = y.get();
-//       maxYIndex = y.index();
-//     }
-//   }
-
-//   // Compute weighted average around XY to smooth the position
-//   if (maxXBinContent || maxYBinContent) {
-//     float tmpX{histConf.lowHistBoundariesXYZ[0] + histConf.binSizeHistX * maxXIndex + histConf.binSizeHistX / 2};
-//     float tmpY{histConf.lowHistBoundariesXYZ[1] + histConf.binSizeHistY * maxYIndex + histConf.binSizeHistY / 2};
-//     int sumX{maxXBinContent};
-//     int sumY{maxYBinContent};
-//     float wX{tmpX * static_cast<float>(maxXBinContent)};
-//     float wY{tmpY * static_cast<float>(maxYBinContent)};
-//     for (int iBinX{std::max(0, maxXIndex - histConf.binSpanXYZ[0])}; iBinX < std::min(maxXIndex + histConf.binSpanXYZ[0] + 1, histConf.nBinsXYZ[0] - 1); ++iBinX) {
-//       if (iBinX != maxXIndex) {
-//         wX += (histConf.lowHistBoundariesXYZ[0] + histConf.binSizeHistX * iBinX + histConf.binSizeHistX / 2) * histX.at(iBinX);
-//         sumX += histX.at(iBinX);
-//       }
-//     }
-//     for (int iBinY{std::max(0, maxYIndex - histConf.binSpanXYZ[1])}; iBinY < std::min(maxYIndex + histConf.binSpanXYZ[1] + 1, histConf.nBinsXYZ[1] - 1); ++iBinY) {
-//       if (iBinY != maxYIndex) {
-//         wY += (histConf.lowHistBoundariesXYZ[1] + histConf.binSizeHistY * iBinY + histConf.binSizeHistY / 2) * histY.at(iBinY);
-//         sumY += histY.at(iBinY);
-//       }
-//     }
-
-//     const float beamCoordinateX{wX / sumX};
-//     const float beamCoordinateY{wY / sumY};
-
-//     // create actual pseudobeam line
-//     Line pseudoBeam{std::array<float, 3>{beamCoordinateX, beamCoordinateY, 1}, std::array<float, 3>{beamCoordinateX, beamCoordinateY, -1}};
-
-//     // Fill z coordinate histogram
-//     for (auto& line : mTracklets) {
-//       if (Line::getDCA(line, pseudoBeam) < mVrtParams.histPairCut) {
-//         ClusterLines cluster{line, pseudoBeam};
-//         histZ(cluster.getVertex()[2]);
-//       }
-//     }
-//     for (int iVertex{0};; ++iVertex) {
-//       int maxZBinContent{0};
-//       int maxZIndex{0};
-//       // find maximum
-//       for (auto z : indexed(histZ)) {
-//         if (z.get() > maxZBinContent) {
-//           maxZBinContent = z.get();
-//           maxZIndex = z.index();
-//         }
-//       }
-//       float tmpZ{histConf.lowHistBoundariesXYZ[2] + histConf.binSizeHistZ * maxZIndex + histConf.binSizeHistZ / 2};
-//       int sumZ{maxZBinContent};
-//       float wZ{tmpZ * static_cast<float>(maxZBinContent)};
-//       for (int iBinZ{std::max(0, maxZIndex - histConf.binSpanXYZ[2])}; iBinZ < std::min(maxZIndex + histConf.binSpanXYZ[2] + 1, histConf.nBinsXYZ[2] - 1); ++iBinZ) {
-//         if (iBinZ != maxZIndex) {
-//           wZ += (histConf.lowHistBoundariesXYZ[2] + histConf.binSizeHistZ * iBinZ + histConf.binSizeHistZ / 2) * histZ.at(iBinZ);
-//           sumZ += histZ.at(iBinZ);
-//           histZ.at(iBinZ) = 0;
-//         }
-//       }
-//       if ((sumZ < mVrtParams.clusterContributorsCut) && (iVertex != 0)) {
-//         break;
-//       }
-//       histZ.at(maxZIndex) = 0;
-//       const float vertexZCoordinate{wZ / sumZ};
-//       mVertices.emplace_back(beamCoordinateX,
-//                              beamCoordinateY,
-//                              vertexZCoordinate,
-//                              std::array<float, 6>{0., 0., 0., 0., 0., 0.},
-//                              sumZ,
-//                              0.,
-//                              mEvent->getROFrameId());
-//     }
-//   }
-// }
+  // std::sort(clusterLines.begin(), clusterLines.end(),
+  //           [](ClusterLines& cluster1, ClusterLines& cluster2) { return cluster1.getSize() > cluster2.getSize(); }); // ensure clusters are ordered by contributors, so that we can cut after the first.
+  // bool atLeastOneFound{false};
+  // for (int iCluster{0}; iCluster < nClusters; ++iCluster) {
+  //   bool lowMultCandidate{false};
+  //   if (atLeastOneFound && (lowMultCandidate = clusterLines[iCluster].getSize() < mVrtParams.clusterContributorsCut)) { // We might have pile up with nContr > cut.
+  //     float beamDistance2{(mTimeFrame->getBeamX() - clusterLines[iCluster].getVertex()[0]) * (mTimeFrame->getBeamX() - clusterLines[iCluster].getVertex()[0]) +
+  //                         (mTimeFrame->getBeamY() - clusterLines[iCluster].getVertex()[1]) * (mTimeFrame->getBeamY() - clusterLines[iCluster].getVertex()[1])};
+  //     lowMultCandidate &= beamDistance2 < mVrtParams.lowMultXYcut2;
+  //     if (!lowMultCandidate) { // Not the first cluster and not a low multiplicity candidate, we can remove it
+  //       clusterLines.erase(clusterLines.begin() + iCluster);
+  //       nClusters--;
+  //       continue;
+  //     }
+  //   }
+  //   float rXY{std::hypot(clusterLines[iCluster].getVertex()[0], clusterLines[iCluster].getVertex()[1])};
+  //   if (rXY < 1.98 && std::abs(clusterLines[iCluster].getVertex()[2]) < mVrtParams.maxZPositionAllowed) {
+  //     atLeastOneFound = true;
+  //     mVertices.emplace_back(clusterLines[iCluster].getVertex()[0],
+  //                            clusterLines[iCluster].getVertex()[1],
+  //                            clusterLines[iCluster].getVertex()[2],
+  //                            clusterLines[iCluster].getRMS2(),         // Symm matrix. Diagonal: RMS2 components,
+  //                                                                      // off-diagonal: square mean of projections on planes.
+  //                            clusterLines[iCluster].getSize(),         // Contributors
+  //                            clusterLines[iCluster].getAvgDistance2(), // In place of chi2
+  //                            rofId);
+  //     if (mTimeFrame->hasMCinformation()) {
+  //       mTimeFrame->getVerticesLabels().emplace_back();
+  //       for (auto& index : clusterLines[iCluster].getLabels()) {
+  //         mTimeFrame->getVerticesLabels().back().push_back(mTimeFrame->getLinesLabel(rofId)[index]); // then we can use nContributors from vertices to get the labels
+  //       }
+  //     }
+  //   }
+  // }
+  // std::vector<Vertex> vertices;
+  // for (auto& vertex : mVertices) {
+  //   vertices.emplace_back(o2::math_utils::Point3D<float>(vertex.mX, vertex.mY, vertex.mZ), vertex.mRMS2, vertex.mContributors, vertex.mAvgDistance2);
+  //   vertices.back().setTimeStamp(vertex.mTimeStamp);
+  // }
+  // mTimeFrame->addPrimaryVertices(vertices);
+  // mVertices.clear();
+}
 } // namespace its
 } // namespace o2

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -118,8 +118,10 @@ void trackletSelectionKernelHost(
         if (!usedTracklets[iTracklet01] && deltaTanLambda < tanLambdaCut && deltaPhi < phiCut && validTracklets != maxTracklets) {
           usedTracklets[iTracklet01] = true;
           destTracklets.emplace_back(tracklets01[iTracklet01], clusters0.data(), clusters1.data());
-          printf("rof: %d ", rof);
-          destTracklets.back().print();
+          if (rof < 153) {
+            // printf("rof: %d ", rof);
+            destTracklets.back().print();
+          }
           if (trackletLabels.size()) {
             linesLabels.emplace_back(trackletLabels[iTracklet01]);
           }
@@ -305,6 +307,9 @@ void VertexerTraits::computeTrackletMatching()
       rofId,
       mVrtParams.tanLambdaCut,
       mVrtParams.phiCut);
+    if (rofId == 152) {
+      LOGP(info, "found lines cpu: {}", mTimeFrame->getLines(rofId).size());
+    }
   }
 
 #ifdef VTX_DEBUG

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -52,20 +52,6 @@ void trackleterKernelHost(
   const int ZBins{utils.getNzBins()};
   // loop on layer1 clusters
   int cumulativeStoredTracklets{0};
-  // if (rof == 0) {
-  // printf("number of clusters: %d\n", clustersCurrentLayer.size());}
-  // print indextablenext
-  if (rof == 152 && Mode == TrackletMode::Layer0Layer1 && DryRun) {
-    printf("nClCur: %d nClNex: %d\n", clustersCurrentLayer.size(), clustersNextLayer.size());
-
-    for (int i = 0; i < PhiBins * ZBins + 1; ++i) {
-      printf("%d ", indexTableNext[i]);
-      if (i % ZBins == 0)
-        printf("\n");
-    }
-    printf("\n");
-  }
-
   for (int iCurrentLayerClusterIndex = 0; iCurrentLayerClusterIndex < clustersCurrentLayer.size(); ++iCurrentLayerClusterIndex) {
     int storedTracklets{0};
     const Cluster& currentCluster{clustersCurrentLayer[iCurrentLayerClusterIndex]};

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -52,6 +52,20 @@ void trackleterKernelHost(
   const int ZBins{utils.getNzBins()};
   // loop on layer1 clusters
   int cumulativeStoredTracklets{0};
+  // if (rof == 0) {
+  // printf("number of clusters: %d\n", clustersCurrentLayer.size());}
+  // print indextablenext
+  if (rof == 152 && Mode == TrackletMode::Layer0Layer1 && DryRun) {
+    printf("nClCur: %d nClNex: %d\n", clustersCurrentLayer.size(), clustersNextLayer.size());
+
+    for (int i = 0; i < PhiBins * ZBins + 1; ++i) {
+      printf("%d ", indexTableNext[i]);
+      if (i % ZBins == 0)
+        printf("\n");
+    }
+    printf("\n");
+  }
+
   for (int iCurrentLayerClusterIndex = 0; iCurrentLayerClusterIndex < clustersCurrentLayer.size(); ++iCurrentLayerClusterIndex) {
     int storedTracklets{0};
     const Cluster& currentCluster{clustersCurrentLayer[iCurrentLayerClusterIndex]};
@@ -66,6 +80,9 @@ void trackleterKernelHost(
         const int firstBinIndex{utils.getBinIndex(selectedBinsRect.x, iPhiBin)};
         const int firstRowClusterIndex{indexTableNext[firstBinIndex]};
         const int maxRowClusterIndex{indexTableNext[firstBinIndex + ZBins]};
+        if (rof == 152) {
+          printf("\t\t => %d %d \n", firstRowClusterIndex, maxRowClusterIndex);
+        }
         // loop on clusters next layer
         for (int iNextLayerClusterIndex{firstRowClusterIndex}; iNextLayerClusterIndex < maxRowClusterIndex && iNextLayerClusterIndex < static_cast<int>(clustersNextLayer.size()); ++iNextLayerClusterIndex) {
           const Cluster& nextCluster{clustersNextLayer[iNextLayerClusterIndex]};

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -66,9 +66,6 @@ void trackleterKernelHost(
         const int firstBinIndex{utils.getBinIndex(selectedBinsRect.x, iPhiBin)};
         const int firstRowClusterIndex{indexTableNext[firstBinIndex]};
         const int maxRowClusterIndex{indexTableNext[firstBinIndex + ZBins]};
-        if (rof == 152) {
-          printf("\t\t => %d %d \n", firstRowClusterIndex, maxRowClusterIndex);
-        }
         // loop on clusters next layer
         for (int iNextLayerClusterIndex{firstRowClusterIndex}; iNextLayerClusterIndex < maxRowClusterIndex && iNextLayerClusterIndex < static_cast<int>(clustersNextLayer.size()); ++iNextLayerClusterIndex) {
           const Cluster& nextCluster{clustersNextLayer[iNextLayerClusterIndex]};
@@ -105,6 +102,7 @@ void trackletSelectionKernelHost(
   std::vector<Line>& destTracklets,
   const gsl::span<const MCCompLabel>& trackletLabels,
   std::vector<MCCompLabel>& linesLabels,
+  int rof,
   const float tanLambdaCut = 0.025f,
   const float phiCut = 0.005f,
   const int maxTracklets = static_cast<int>(1e2))
@@ -120,6 +118,8 @@ void trackletSelectionKernelHost(
         if (!usedTracklets[iTracklet01] && deltaTanLambda < tanLambdaCut && deltaPhi < phiCut && validTracklets != maxTracklets) {
           usedTracklets[iTracklet01] = true;
           destTracklets.emplace_back(tracklets01[iTracklet01], clusters0.data(), clusters1.data());
+          printf("rof: %d ", rof);
+          destTracklets.back().print();
           if (trackletLabels.size()) {
             linesLabels.emplace_back(trackletLabels[iTracklet01]);
           }
@@ -302,6 +302,7 @@ void VertexerTraits::computeTrackletMatching()
       mTimeFrame->getLines(rofId),
       mTimeFrame->getLabelsFoundTracklets(rofId, 0),
       mTimeFrame->getLinesLabel(rofId),
+      rofId,
       mVrtParams.tanLambdaCut,
       mVrtParams.phiCut);
   }

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -118,10 +118,6 @@ void trackletSelectionKernelHost(
         if (!usedTracklets[iTracklet01] && deltaTanLambda < tanLambdaCut && deltaPhi < phiCut && validTracklets != maxTracklets) {
           usedTracklets[iTracklet01] = true;
           destTracklets.emplace_back(tracklets01[iTracklet01], clusters0.data(), clusters1.data());
-          if (rof < 153) {
-            // printf("rof: %d ", rof);
-            destTracklets.back().print();
-          }
           if (trackletLabels.size()) {
             linesLabels.emplace_back(trackletLabels[iTracklet01]);
           }
@@ -307,9 +303,6 @@ void VertexerTraits::computeTrackletMatching()
       rofId,
       mVrtParams.tanLambdaCut,
       mVrtParams.phiCut);
-    if (rofId == 152) {
-      LOGP(info, "found lines cpu: {}", mTimeFrame->getLines(rofId).size());
-    }
   }
 
 #ifdef VTX_DEBUG

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -214,7 +214,8 @@ void TrackerDPL::run(ProcessingContext& pc)
     auto& vtxROF = vertROFvec.emplace_back(rofspan[iRof]);
     vtxROF.setFirstEntry(vertices.size());
     if (mRunVertexer) {
-      auto vtxSpan = timeFrame->getPrimaryVertices(iRof);
+      auto vtxSpan = gsl::span<const Vertex>();
+      // timeFrame->getPrimaryVertices(iRof);
       vtxROF.setNEntries(vtxSpan.size());
       bool selROF = vtxSpan.size() == 0;
       for (auto iV{0}; iV < vtxSpan.size(); ++iV) {


### PR DESCRIPTION
- Protections added in DCS DPs processing (#10215)
- DPL: fix warning
- DPL: add helper to wrap algorithms
- TRD: Tracker: Add padrow crossing information (#10229)
- Fix mask of MFTMCHMID
- Add test workflow for analysis
- small fix for collision context tool
- Fix TPC_WORKFLOW_FILTER_DIGITS_OUTSIDE_OF_TF
- Use LOG(alarm) instead of std::cerr
- Calib workflow: fix error messages
- If MFTMCH and MCHMID are enabled, enable MFTMCHMID as well in EventDisplay
- TRD: calibration: vDrift and ExB (#10053)
- optionally throttle CCDB logs to infologger
- Demote ccdb query announce and /Returning cached entry/ logging to debug
- IDC deltas always on
- update SCALETRACKS_TPC_TIMEGAIN
- [FOCAL-9] Write decoded ASIC header to tree
- CollisionContext: Option to ensure that a timeframe has at least one collision
- TRD: QC: Add global track id to TrackQC (#10300)
- DPL: rate limiting
- Optionally truncate TPC digits that fall beyond orbit limit
- Fix: SYNTHETIC and NOISE run types were swapped
- Fit the full candidate with KF (#10271)
- CM Pad-by-Pad option, load pad variations from CCDB, CM corrected digits
- GPU: Fix initialiation of GPU magnetic field if 0-field should be used but magnet current is not exactly 0
- DPL: fix warnings in ASoA.h
- TPC: Add debug option to dump CompressedClusters struct to stdout
- TPC Track Model Decoding: Better cuts to distinguish underflow / overflow
- Make some functions static, fix a typo
- TPC: CTF Skimming should use correct solenoidBz and nHbfPerTf
- TPC CTF Skimming: Fix possible overflow in BC range check
- DPL: avoid copying the TaskName too often
- DPL: fix warnings in histogram registry
- HistogramRegistry: avoid unneded copies and allocations
- HistogramRegistry: avoid dance back and forward with types
- [FT0] Quick fix of errors in SYNTHETIC runs (set DataIsValid flag in sim)
- DPL: fix typo in documentation
- Fix printout in TPCVDriftTglCalibSpec
- Fix SVertexer: vector element ref. used after vector expansion
- Add countsFV0 to LumiInfo as backup for nominal FT0 lumi
- Dummy driver device with no input and dummy output
- Barrel alignment fixes
- FST: Give proper error message when rawAll.cfg missing
- FST: Option to enable / disable QED part
- GPU Workflow: fix configKeyValue to override solenoidBz
- Reduce some debug verbosity
- GPU: Display of magnetic field should create field from GRP if not already loaded
- GPU: Standalone visualization can run without data
- TPC CTF Skimming: Implement eta-cut on unassigned clusters
- TPC: Do not check triggered mode setting if TPC is not read out
- CPV: add dpl ccdb fitcher to digitizer
- [ITS, ITS3] Add first version of ITS3 descriptor in ITS geometry (#10289)
- Allow to set the MID HV from CCDB
- TRD: Simplify link stats (#10315)
- Make sure detector CTF header default constructor is called
- TRD fix digit phase comments (#10331)
- ctpdev: scalers reply (#10317)
- DPL: set TimingInfo field accordingly on new Run
- Remove stray GlobalFwdTrackReaderSpec file
- Make the track color configurable in EventDisplay
- TPC Track Model Compression: Store Bz field and max time bin with data
- first version of DCS config proxy
- Second version of TPC DCS Config proxy
- L1phase calib summary histo added; warning fixes
- [FWDMatcher] Protection for invalid BC diff
- ITS DCS parser: add always run number to metadata (#10320)
- [FOCAL-9] Port mapping for pads from QC
- fix in TOF matching (time) to account for integrated times
- Optionally apply BC shift to triggered detectors in CTF decoding
- [EMCAL-841] Fix switched energy and time in cell calibration
- TRD: QC: Enable output for full configuration (#10307)
- FST: Fix problem with NUMA pinning in 4-gpu workflow
- FST: OPTIMIZED_PARALLEL_ASYNC should only be set externally
- Fix TPC Entropy encoder with dictionary from CCDB tree object
- o2-sim: fail hard upon errors during loading cuts from JSON
- Add track size enlargement for EventDisplay screenshots
- Special treatment for shifts of ZDC triggers at BC=0,3563
- Fix TPC CTF IO test
- Update RuntimeError.cxx
- Fix swapped pitch and yaw angles in the AlignParam
- When root-outputs are requested, write also TRD tracklets/digits
- Introduce optional ITS ROF delay in nBC in the AlpideParam
- Account for possible ITS ROF delay in ITS-TPC matching
- account for eventual ITS/MFT ROF bias in vertexing/matching
- Introduce optional global time bias for ITS-TPC refitted time
- Update MCTrack ClassDef
- Make HepMC and native status available for MC gen
- Simplify logic for file output setting of residual aggregator
- Replace CTF_METAFILES_DIR by EPN2EOS_METAFILES_DIR
- ZDC calib: configure meta file and output dirs
- PHOS calib: configure meta files and output dirs
- Fix workflow scripts to pass FST without O2DPG update
- ctpdev: FV0 to lumi (#10349)
- Disable MFT Tracker IR filter for cosmic runs
- Fix MFT tracker for  B=0
- add CTP digit writer executable
- Possibility to add custom workflow via ADD_EXTRA_WORKFLOW
- Set Alpide random noise to 10^-8 (was 10^-7)
- Report S,P.vertexer settings only once from pipeline 0
- DPL GUI: avoid crash while I find out why the metrics are not correct
- Fix in creation of alignment object
- Add an end of validity to the default MID HV CCDB object
- In case of alien directory connect to alien://, do not validate in advance
- Make sure readers can read from alien
- FST: Add pipeline option for HMPID
- FST: Fix TIMEFRAME_SHM_LIMIT for raw/tf/ctf reader case
- TPC zs Encoder: fix on the fly ion tail correction
- [OCTRL-731] Use config.Get instead of deprecated GetConfig in AliECS output
- Revert "Fix workflow scripts to pass FST without O2DPG update"
- Fixes for the barrel allignment
- Fix order of alignment objects application
- GPU: TPC TF Cluster Check
- fix filling of eta histo
- Possibility to add EMC recalib for async
- Option to fowards MC tracks from O2-sim to external (DPL) consumer
- fix sim example
- TPC: Adjust DLBZS format to what is implemented in the firmware
- TPC: fix o2-tpc-reco-workflow with input = compressed clusters from CTF and output = ClustersNative
- Add more CRU configuration parameters
- TRD tracking: update default settings
- PHOS calibrations check file path in device init
- TPC gain map using tracks: Perform log transform of Q
- TOF: Add unfied container for parameters on ccdb (#10364)
- GPU: Add tuning parameters for AMD MI2xx
- GPU: Automatically select best AMD GPU kernel parameters based on HIP_AMDGPUTARGET
- DPL GUI: improve display when there is a lot of edges
- Make sure calo table is sorted by BC (#10381)
- Report N contributors/ambiguous in p.vertex reader verbose mode
- use cov.matrix eigenvalues for num.derivative deltas
- Optionally gzip mille binary files
- Optionally downscale MP output records in root format
- GPUTRDTrack move getter method to header
- [FOCAL-9] Force writing pad tree at the end of stream
- [EMCAL-830] Options to drop or redirect cells from LED events
- make kine forward channel unique per sim process
- Optionally add extra time error to ITSTPC tracks
- Fix TPC digi time comparison
- DPL GUI: avoid reallocating buffers over and over again
- Add option to quit on successful sending
- switch from degrees to radians, accound Vtx extra error
- Protection against 0 or negative eigenvalues of cov.matrix
- Option to generate params/constraints files w/o processing
- Add cuts on N tracklets/clusters, print seen/acc. stat.
- [EMCAL-830] Stream EMCAL LED events to dedicated ROOT files
- Updated TimeSlotCalibration interface
- MID tracker does not need MagField
- Fix material and thickness of OB CYSS elements
- Fix typos in material definition
- [ITS] Implement ITSBase configurable parameters
- DPL GUI: do not expose getDataJSON
- Avoid using deprecated sprintf
- Please consider the following formatting changes
- DPL: avoid regex recompilation
- DPL: Fix warning
- [EMCAL-798] Add input subspecification to offline calib workflow
- [EMCAL-798] Fix: Argument was not in quotation marks
- DPL: Improve ControlServiceHelpers::parseControl
- DPL: move DeviceConfigInfo::parseConfig to C++17
- TPC IDC aggregator workflow: use 1 proxy for IDCs and SACs
- simple workflow to process ClusterQC
- TPC: adding workflow for integrated cluster currents
- Use new ITS FLPs in raw2digit [O2-3443]
- report volume ID in parames printout
- Write measurement record with pre-sigma constraint
- TPC SCD calib: add configurable params
- Residuals filename contains TFID info
- Always write track references in addition to binned residuals
- Prepare limiting number of processed tracks per TF
- ITS Calibration: small fixes and calculation of mpv (#10401)
- MFT tracks: chi2 per number of degrees of freedom
- Bugfix and cleanup MFT track finder
- tof digitizer reads params from ccdb
- apply delay in tof digit reader
- add MatchTOFParams
- Aply MP2 solution to matrices after loading it
- New features to construct digicontexts
- DPL: factor out non-type dependent code
- DPL GUI: avoid multiple calls to node position
- MFT-MCH refit : Removing remnants of old implementation and adding options (#10396)
- [MCH] adapt to variable TF size (for MC) (#10399)
- Change name to tpc-aggregator-ft if it is for SACs
- Replace deprecated set-output command in workflows
- TPC residuals: Add possibillity to use more than one input file
- TPCFastTransform: Add possibillity to write splines to file
- TPC: Add option to shift TPC clusters during decoding
- DPL: fix warnings
- TRD: CalibratorVdExB: Fix minimal entries init
- TPC: install TPCFastTransformInit.C (#10440)
- MCTrack proxy: option to pass source PID or to find socketfile
- Log full value of the HMP DP in verbose mode
- Fix status code usage in MCUtils
- [EMCAL-798] Apply gain calibration to cell energies in offline calib
- Add Collisions table version 001
- o2-sim: Generalized vertex sampling
- Move config.macro exec. after eventual ini.params reading
- Fixes for alignment: match any volume by regexp
- ICCs: Add option to select charge type (qMax or qTot)
- ICCs: Adding missing suffix to CMake
- [MCH] added time information to Track class
- [MCH] added unit test for interaction record conversion
- [MCH] fixed clang formatting
- [MCH] added review comments
- [MCH] added back limits header
- Fix copy constructor for TimeSlot
- [FOCAL-10] Basic FOCAL raw decoding workflow
- TPC SCD calib: Ues time stamps for filenames and some fixes for merging slots
- Proper track sampling for residuals extraction
- Track info makes sense only for unbinned residuals
- Multiple fixes for the alignment
- First prototype of strangeness tracking workflow (#10437)
- Fix clang-tidy reported issues
- TPC fast transform: Add user defined number of knots
- Update CODEOWNERS
- DPL: improve simple sink
- DPL: allow getting all the ConfigParamSpec from a ConfigRegistry
- DPL: improve simple source device
- getNFakeClusters() now starts reading from the first hit
- Ability to use pre-fixed collision vertices in simulation
- remove one print if not verbose mode
- optimizing TOF event time maker
- fix when reading TOF diagnotic
- TPC ICCs/IDCs: fixing completion policy for ICCs
- prototype for the CTP inputs storage in AOD (#10400)
- [EMCAL-798] Add gain calib flag to offline calibrator
- FIT calibration: new features and fixes (#10451)
- Fix SCD calib maxTracksPerCalibSlot=-1 option
- add method to get alignable volume by its label
- Change cluster def to common side; bugfix
- Refine gen status code usage
- Get MID HV from CCDB in simulations
- Use recodata + ITS-V0 PV match (#10460)
- load mag field from CCDB
- Revert "prototype for the CTP inputs storage in AOD (#10400)"
- [FOCAL-10] Enable pixel mapping in build
- Drop need for DataTakingContext for now
- Workflow for the study of TPC tracks moving effects
- Provide trivial MC engine and application
- improve error message
- [ITS, ITS3] Implement Dead Zones and Carbon Foam for ITS3 Inner Barrel (#10477)
- GPU: Fix compiler warning
- TPC: Improve TPC cluster counting tool and add afterglow counting
- FT0 calib&reco update (#10480)
- Fix BunchCrossings LUT to hadlde large BC spans
- normalize the propagation of digits along the reconstruction chain
- ITS Calib: trivial fix to s-curve fit
- DPL: drop obsolete example
- DPL: provide helpers to navigate O2 Data Model
- DPL: add helper to check if some Lifetime::Timeframe output is missing
- Require alien token for all https URLs and for alice-ccdb.cern.ch, throw fatal if not present
- CCDB: Add alien token check as proposed by Sandro
- fix typo in alien-token check
- Avoid deprecation warnings
- TPC SCD map creation from unbinned residuals (#10479)
- Optionally apply fixed BC shift to CTP data decoded from CTF
- TPC: Check if all input files are accessible (#10498)
- Change to using Collisions = Collisions_001 (#10478)
- Fix in the VDrift selection logic
- Add ITS3-WP1 coordinators as CODEOWNERS of IT3 folder (#10481)
- Optional q/pT cutoff for tracks used for TPC Vdrift calibration
- [ITS3, ITS] Add possibility to switch ITS3 version with configKeyValues (#10488)
- TPC: cpad function for simple cluster drawing
- Make sure MC particles are ordered by MC collision IDs
- Fix TRD refit LT-integral calculation and material accounting (#10509)
- GPU: Fix TPC track merging with uneven number of threads
- GPU: Add support for compressed clusters to standalone dump
- GPU: Add cmake option to disable all fast-math and non ieee denormal treatments
- collision version 001 fixup (#10513)
- QC: Adds IDC0 scale and Draw Overview
- GPU: In case of empty (0-size message) CTF input, assume we have empty date
- GPU: GPUCA_NO_FAST_MATH should also avoid fma contraction
- GPU: Support GPUCA_NO_FAST_MATH also for GPU library in non standalone-compilation
- TPC: Show warning if clusters fail track model decoding
- GPU: Do not auto-detect AMD clang-ocl, since it has compiler problems, and can break O2 compiltion if auto-detected
- GPU: Fix compiler warning
- GPU: Improve ROCm path auto-detection, if not set but /opt/rocm exists, just use it
- TPC: adding number of clusters as type for integration
- ITS: Implement AlpideResponseSimulation, on-the-fly root file generation, and more. (#10352)
- DPL Analysis: fix unit tests
- CMake: fix FindO2GPU syntax
- DPL: cleanup InputRecord::get
- Fix: revert ITS/MFT cluster dict. hashing to original murmur2 f-n
- GPU: Improve debug output
- GPU: Update OuterTrackParam during inward refit at innermost leg
- GPU: Store OuterParam already after refit of first leg in second to last round
- GPU: When dropping secondary legs, remove attachment of clusters that belong to the primary leg of a different track
- DPL Analysis: use human-readable types in expression errors (#10515)
- add passName in DigiParams
- DPL Analysis: simplify Join and update Concat (#10516)
- GPU: Indent debug output correctly
- GPU: Fix storage of OuterParam if first inward fits aborts early but final inward fit succeeds
- GPU: Fix cluster-attachment leg assignment for CE crossing tracks
- Revert "Use https for alice-ccdb.cern.ch"
- GPU: Fix ROCm path auto-detection
- Optimize St4-5 clustering - preparing comparaison between the 2 algorithms (#10457)
- DPL Analysis: simplify code to parse inputs
- Add metadata to AOD writer inputs (#10531)
- DPL Analysis: initial support for enumerations
- DPL Analysis: avoid calculating the hash multiple times
- DPL: introduce test for DatabasePDG
- Check/fix for wraps in InteracitonRecord arithmetic
- added compatibility with data produced with IB commissioning tools (#10505)
- Allow usage of additional track information for TPC SCD map creation (#10537)
- [QC-898] Rename RAW channel type into RAWFMQ
- DPL Analysis: correctly account for offset when accessing sliced boolean column
- DPL Analysis: load PDG database on demand
- DPL: fix missing includes
- Include EMCAL and PHOS/CPV in fake CTP readout (#10544)
- FileFetcher run alien_cp in debug mode
- Optional threshold on fraction or abs.number of failed fetches
- New developments for QED treatment in simulation
- merge and relocate tracking workflows
- TRD: PID: Added Base Classes
- TRD: GPU: added Signal member to GPUTRDTrack_t
- TRD: Tracking: Adding PID capabilities
- AOD: TRD: Add PID information
- AOD: TRD: Add track information
- Fix timerange for Mean Photon Energy
- Kr calibration - normalized gain maps (#9800)
- FT0 reco: time calc default filter parameters are changed
- Temporary remove alpide test
- Improve robustness for ITSRESPONSE location pt. 1
- GPU Display: temporarily disable imgui text rendering, for imgui bump
- DPL GUI: add compatibility with DebugGUI v0.7.0
- DPL: use transparent wrapper for LoadableServicePlugin
- Generic workflow to study tracking results.
- Refine and add utilities for MCGenStatus
- Add CheckVertices macro (#10555)
- ctp: trigger offsets and config tests (#10567)
- [FOCAL-10] Add option to process multiple files in pad rootifier
- add electronic noise and time response
- GPU: Workaround disabling fast-math on AMD GPUs, since it crashes
- Bugfix minimal number of ROFs per MFT tracker thread
- DPL GUI: Try to get newly deprecated code to work
- Update FrameworkGUIDebugger.cxx
- Drop direct dependency on libPhysics
- Fix compiler warnings
- GPU: Fix setting of GPU device ID from ROCR_VISIBLE_DEVICES without explicit NUMA setting of sync reco
- Discard TRD tracks with bad quality (#10540)
- Consistently use the systematics alignment variance (#10574)
- CCDBManager: Set condition-not-after in constructor when env variable is set
- Fix detection of CCDB production server in CcdbApi
- DPL Analysis: add a static constexpr function to check if a Join contains certain component (#10578)
- GPU QA: Add debug output
- GPU: Use average eta estimate for initial ZOffset during track seeding
- GPU: Assume average eta for vertex time estimate for looping tracks not coming close to the beam line
- GPU: Improve vertex time estimation
- Improve error message, add one possible cause of failure that caused the crash, which was not mentioned before
- Fix leftover debug message
- [ITS3, ITS] Modify the description of carbon foam (#10520)
- Update track selection for track interpolation
- Macro for creating average distortion maps
- Skip data before TF start is fount in detect-tf0 mode
- Misc. fixes for the pvertexer.
- make track print methods to work on gpu
- fixes in log messages
- TPC refit of TrackParCof resets q/pt err.to 100/1000% for large/small q/pTs
- o2-sim: Support for low energy neutron transport (Geant4 and Fluka) (#10585)
- Another fix for CCDB server detection
- Upgrade MFT track finder
- Default settings for MFT track finder
- [MFTAssessment] Add Histograms for fake tracks
- activate time dispersion and time clustering in MC
- [FOCAL-10] Fixes for merging pad and pixel data
- [FOCAL-10] Fixes in EventReader
- ITS: Improve seeding with low multiplicity events
- Add meanvertex pull from ccdb
- Fix parameter not propagated
- Use reusable workflow for clean-test
- Update README for TPC SCD calib
- Add more cut parameters for track selection
- treat MC QED background labels as not valid
- [FOCAL-10] Skip empty HBFs in decoding
- [EMCAL-565] Add energy interval above 4GeV for bad channel calib
- GPU TPC: For constraining track time0, use all clusters, not only those that were not reject in current refit round
- GPU TPC: Fix constraining of TPC track time0
- GPU TPC: Constrain time window to compute deltaFwd / deltaBwd to the TPC drift time
- GPU TPC: Track with eta ~ 0 with clusters removed can increase the time range between first and last cluster, thus reconstrain time0 when storing
- Change lifetime::timeframe to sporadic in several places
- GPU QA: Drop obsolete csvDump function
- GPU: Standalone build should create ROOT dictionaries if ROOT is present
- GPU: Add dictionary for GPUTPCGMMergedTrackHit
- GPU: Improve GPUROOTDump, allow output to multiple branches of a tree
- GPU QA: Add option to dump clusters and tracks to ROOT file
- Calib Workflow: Fix TPC SAC workflow without IDCs
- [FOCAL-11] Provide simple base analysis task for TB events
- ITS: Fix crash due to initalised vertex on some OSs
- GPU TPC: Fix sign of maxDriftTime when computing time window constraint
- revert accidentally enable debug output of vertexer
- Account for pre/post trigger pileup in TRD timing estimate
- Set nominal TRD track time error to 5ns
- Make TOF matching time tolerance nSigma configurable (def=4, was 30)
- Fix RDH error bits decoding (#10577)
- [FDD] Now propagate avg time for all the BCs in Rec  (#10545)
- TRD raw reader improve RDH check
- ITS: Add protection from bogus vtx coordinate (#10600)
- Separate cluster attachment chi2 from total chi2 selections (#10592)
- DPL: add profiling policy for message size (#10613)
- DPL: attempt at hiding boost deprecation message (#10614)
- Revert "Add metadata to AOD writer inputs (#10531)"
- Fix outlier rejection for B=0 data
- DPL: translate FairLogger's detail to Infologger's debug (#10615)
- MCH: properly configure the slot finalization (#10566)
- Avoid alien check being confused by IgProf
- Add option to enable -ftime-trace
- Simplify thread safety options
- DPL: use formatter for enum Lifetime
- DPL GUI: display device inputs again
- TPC SAC: Changing name of output
- TPC IDC/SAC: Remove unneeded functions
- DPL: Make sure that DPL proxy ready fast channels fast-enough in multi-channel setup
- Small explanation on boxgen
- Fix deprecation warning
- Accounting for residuals per TF
- Find voxel bin for TPC cluster position, not track interpolation position
- Optionally apply correction map to cluster residuals
- Example how to use MCTrackNavigator in kinematics analysis
- Fix warning
- [FOCAL-11] Drop empty timeframes in reader
- TOF: Adding workflow for integrated TOF currents (#10608)
- DPL Analysis: fix enumerations
- Fix warning
- TPC IDC: optimizing outlier filtering
- Possibility to set MeanVtx calib parameter from outside
- [ITS3] Fix digitization and clusterization and implement proper transformations for ITS3 (#10607)
- DPL: have separate include for RootMessageContext
- [FOCAL-10, FOCAL-11] Fixes in pixel decoding
- Revert "Default settings for MFT track finder"
- Revert "Upgrade MFT track finder"
- Fix typo in socket config preventing o2sim_mctracks_proxy to work
- ITS-digi: Fatalise if response file not found
- Update RunTypes for 2 new calib.types
- DPL: Add Metric which is 1 while processing
- Flag to allow duplicate processing
- Create DCAFitter under ./Common (#10644)
- Update clean-test.yml
- Complain if more than output route
- DPL: add check for missing outputs
- Introduce a StreamContext and extend the DataProcessorContext
- Attempt at making it reliable
- AOD stores tracks parameters at calorimeters (#10611)
- Introduce RDHv7 and related changes for rec/sim
- Adapt ITS/MFT raw decoding and encoding to RDHv7 and no-padding
- Temporary restore setNewFormat method to avoid conflict with QC
- add DCAFitter dedicated library
- Framework: Add TRD Pattern as dynamic columns
- new structure to handle MCH processing errors
- Fix in detection of the CRU page end for RDHv7 ITS data
- Upgrade MFT track finder
- Default settings for MFT track finder
- [MFT] Reduce MaxRPhiBins to minimize memory size reduce `o2::mft::constants::index_table::MaxRPhiBins' to accomodate default MFT tracking parameters.
- [EMCAL-830] Handling of MC labels
- GPU TPC: Accept RDH >= 6 for TPC GPU raw decoding
- GPU TPC: Add hitSearchArea2 parameter
- Calib workflow: This is not a fatal error, simply there won't be any input
- Calib Workflow: Fix workflow when TIMEFRAME_SHM_LIMIT is not set
- Request subspec 1 for EMC decoder in raw->AOD mode
- DPL: fix warnings
- MCH: add bpackets output in calibrator (#10653)
- Add TTree aliases for scd map results
- Add vDrift calibration
- DPL: Simplify didReceiveData()
- [O2-3142] DPL: fire uv_timer in smaller intervals
- DPL: try keeping the average timer period duration as requested regardless jitter
- DPL: rely only on uv_timer to decide when to create timer inputs
- DPL: Use std::vector instead of std::set for firedTimers
- DPL: set the requested uv_timer period just once
- Changes for CRU suppression of zeroes
- DPL: drop RawBufferContext
- CODEOWNERS: Fix ITS3 directory
- TPC Entropy Encoder: Use correct getter for max drift time
- dpl-workflow: add writers for EMC, CPV, CTP, PHS
- Add missing include
- Remove unused file
- dpl-workflow: Add parameter WORKFLOW_DETECTORS_USE_GLOBAL_READER
- Add --onlyDet option to raw-file-reader-workflow
- FV0: BugFix: Fix inverted MC argument in digit reader
- MID: Add setting for digit tree name, and use MIDROFRecords for ROF record branch to have the same name as when the simulation creates the digits file
- dpl-workflow: add some readers / writers needed for QC
- MCH: Bugfix: runDataProcessing must be included after customize funcitons
- TRD: Add standalone digit reader workflow
- dpl-workfow: add more readers/writers needed for QC in split dpl-workflow
- fix for decoding unpadded ITS/MFT data with RDHv7
- Allow map extraction for B=0 data
- dpl-workflow: Use --onlyDet option for raw file reader
- ITS-SV: fix aggressive rounding in determinant (#10668)
- added correct counting of total number of strobes in Norm mode
- fix command line option for o2-mch-digits-writer-workflow
- TRD: allow compilation w/o ONNXRuntime
- Remove DCAFitter from DetectorsVertexing (#10689)
- GPU: Pass correct GCC toolchain to hipcc, since autodetection seems not to work
- add MCH preclusters reader/writer workflows
- Improve cluster and track filter
- DPL: make adding distsubtimeframe & co stable
- FT0/FV0/TPC: adding workflows for integrated currents (#10663)
- Fix race condition when creating a folder on mac
- FT0 reco: filter for event container and amp container is suppressed
- Add drift time offset to VDrift calibration object
- STDERR monitor: filter TInterpreter warnings
- More equivalency declarations (#10694)
- Sim evalmat for Run5 modules
- dpl-workflow: Add optional TOF digit writer/reader
- TOF: Bugfix: tof-reco-workflow should be able to write digits for all input types but digits
- TOF: Rename tof-digit-writer-workflow, since it uses the DigitWritterSplitterWorkflow, not the DigitWritterWorkflow, which is a bit confusing
- dpl-workflow: Add optional readers for MCH clusterdigits and preclusterdigits
- uniformize MCH digits i/o for data and MC (#10697)
- Adding protections needed for QC
- CMake: MCHWorkflow lib is not needed for CTF I/O.
- Update of datamodel-doc (#10675)
- use default MCH cluster resolution
- Add some info to the Error mesage
- Optimize calorimeter energy aggregation in EventDisplay
- Introduce helper function to load MClabels from a TTree/TFile
- Fix MeanVertex moving average time assignment
- DPL: demoting warning message for now
- Update TRD codeowners
- [MFT] Move static arrays to be initialized before the processing starts (#10665)
- calib-workflow: If EPNSYNCMODE is not set, don't try to connect to FLPs, since it floods the CERN DNS with bogus querries
- dpl-workflow: Add math_min macro
- dpl-workflow: send TOF digits only unconditionally if ROOT output was requested
- Fix missing variable initialization
- Fix length check
- TRD MC->raw uses default RDH unless overridden
- tof-reco-workflow: If input are upstream digits not from a ROOT file, we max actually write them to a ROOT file
- Better memory handling for sparse pp
- ITS3: Base: Make ALPIDE pixel size configurable (#10690)
- ITS3: Sim: Fix calculation of sensor width
- DPL: add DataAllocator::cookDeadBeef method
- GPU: Add printout of HIP version to CMake
- Demote to warning the negative Chi2 log
- Remove unused includes (#10714)
- Adding script to load functions, and possibility to add more wf
- Increase TRD dead time from 0.2 to 11 us
- dpl-workflow: Don't scale up explicitly set process multiplicities with GEN_TOPO_AUTOSCALE_PROCESSES
- Generalize ZDC fast sim to include proton ML models
- Remove sync_misaligned, modernise sync (#10730)
- TPC interpolation with additional ITS-TPC tracks
- add initial and moved TPC cluster info to output tree
- add MCH errors merger, reader and writer (#10716)
- [MFT] Use residual instead of measurement to make Mille records (#10726)
- Avoid segfault if no ITS-TPC tracks available, but additional ITS-TPC tracks are still requested (#10733)
- Introduce GpuTimeFramePartition
- Add checkSize feature
- Add missing allocations
- Add loading clusters
- Add tracer for GPU
- Add async memory loading
- Remove redunant namespace
- Improve flexibility for smaller GPUs (4 dev)
- Add multi-rof trackleter kernel
- WIP: add rof per block logic
- Add buffer recording
- Add async thrust calls
- Add block debug print function
- Checkpointing
- Somenthing moves
- checkpoint
- CP
- cp
- CP
- godo
- asdf
- CP
- Threads stepping on each others, to be fixed
- CP
